### PR TITLE
Sets default CXX std = 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set_up_platform()
 enable_language(C)
 enable_language(Fortran)
 enable_language(CXX)
+set(CMAKE_CXX_STANDARD 11)
 
 # We declare the project here.
 project (haero)


### PR DESCRIPTION
`-std=c++11` seems to be required for yaml_cpp, and conforms with current SCREAM default.