### PR TITLE
Added install target for haero library headers.

### DIFF
--- a/haero/CMakeLists.txt
+++ b/haero/CMakeLists.txt
@@ -30,6 +30,13 @@ set(HAERO_LIBRARIES haero;${HAERO_LIBRARIES} PARENT_SCOPE)
 
 # Installation targets
 install(TARGETS haero DESTINATION lib)
+install(FILES haero.hpp
+              ${CMAKE_CURRENT_BINARY_DIR}/haero_config.hpp
+              mode.hpp
+              physical_constants.hpp
+              species.hpp
+              utils.hpp
+        DESTINATION include/haero)
 
 # Library unit tests.
 add_subdirectory(tests)


### PR DESCRIPTION
Now, when you type `make install`, haero library headers (no driver-related headers) are installed in your given prefix.

I imagine we'll be doing driver-related development exclusively within this repo, so I don't want to encourage other codes to adopt that stuff too easily (there is such a thing as too much reuse!).

Closes #11 
