### PR TITLE
Modifies compy's machine file to replace ifort with gcc

### DIFF
--- a/machines/compy.sh
+++ b/machines/compy.sh
@@ -22,7 +22,7 @@ export NETCDFF_LIBRARY_DIR=$NETCDF_LIBRARY_DIR
 export NETCDFF_LIBRARY=libnetcdff.a
 
 # Set relevant compilers.
-export FC=gfortran
+export FC=mpif90
 export CXX=mpicxx
 
 # Set extra LDFLAGS


### PR DESCRIPTION
The code compiles fine with GCC on Compy. I got into some
issues with the intel compiler. We can revert back to intel
once we resolve those issues.