### PR TITLE
Changes CMake version for the model to 12.0 and updates Compy's cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version -- currently determined by HDF5.
-cmake_minimum_required (VERSION 3.10.0)
+cmake_minimum_required (VERSION 3.12.0)
 
 # Adjust CMake's module path.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")

--- a/machines/compy.sh
+++ b/machines/compy.sh
@@ -3,7 +3,7 @@
 source /etc/profile.d/modules.sh
 
 # Load relevant modules
-module purge && module load cmake/3.11.4 gcc/8.1.0  mvapich2/2.3.1 netcdf/4.6.3
+module purge && module load cmake/3.19.6  gcc/8.1.0  mvapich2/2.3.1 netcdf/4.6.3
 
 
 # Set third-party library paths


### PR DESCRIPTION
CMake minimum required version for Haero is updated to 12.0. Compy's  CMake module is changed to cmake/3.19.6