### PR TITLE
Fix floating point exception.

### DIFF
--- a/haero/processes/mam_nucleation.F90
+++ b/haero/processes/mam_nucleation.F90
@@ -567,7 +567,9 @@ subroutine compute_tendencies(deltat, &
 
   ! dso4dt_ait, dnh4dt_ait are (kmol/kmol-air/s)
   dso4dt_ait = dmdt_ait*tmp_frso4/mw_so4a_host
-  dnh4dt_ait = dmdt_ait*(1.0_wp - tmp_frso4)/mw_nh4a_host
+  if (0.0_wp < mw_nh4a_host) then
+    dnh4dt_ait = dmdt_ait*(1.0_wp - tmp_frso4)/mw_nh4a_host
+  end if
 end subroutine
 
 ! Calculates new particle production from homogeneous nucleation


### PR DESCRIPTION
Did not notice this before because the computed
NaN is not further used in the testing.  Found
via enable exception handling.

With no exceptions in the scalar version, this
should make testing for exceptions in the new
Packed versions easier.