### PR TITLE
Fix bugs found during Intel build

### DIFF
--- a/haero/aerosol_species.hpp
+++ b/haero/aerosol_species.hpp
@@ -33,8 +33,10 @@ struct AerosolSpecies final {
           Real dry_rad,
           Real dens,
           Real hygro):
-    molecular_weight(molecular_wt), dry_radius(dry_rad),
-    density(dens), hygroscopicity(hygro) 
+    molecular_weight(molecular_wt), 
+    dry_radius      (dry_rad),
+    density         (dens), 
+    hygroscopicity  (hygro) 
   {
     EKAT_ASSERT(name.size() < NAME_LEN);
     EKAT_ASSERT(symbol.size() < NAME_LEN);
@@ -43,7 +45,11 @@ struct AerosolSpecies final {
   }
 
   KOKKOS_INLINE_FUNCTION
-  AerosolSpecies(const AerosolSpecies& a) {
+  AerosolSpecies(const AerosolSpecies& a) :
+    molecular_weight(a.molecular_weight), 
+    dry_radius      (a.dry_radius),
+    density         (a.density), 
+    hygroscopicity  (a.hygroscopicity) {
     for (int i=0; i<NAME_LEN; ++i)
        name_view[i] = a.name_view[i]; 
     for (int i=0; i<NAME_LEN; ++i)
@@ -52,6 +58,10 @@ struct AerosolSpecies final {
 
   KOKKOS_INLINE_FUNCTION
   AerosolSpecies &operator=(const AerosolSpecies& a) {
+    molecular_weight = a.molecular_weight; 
+    dry_radius       = a.dry_radius;
+    density          =  a.density; 
+    hygroscopicity   = a.hygroscopicity;
     for (int i=0; i<NAME_LEN; ++i)
        name_view[i] = a.name_view[i]; 
     for (int i=0; i<NAME_LEN; ++i)

--- a/haero/tendencies.cpp
+++ b/haero/tendencies.cpp
@@ -17,23 +17,27 @@ Tendencies::Tendencies(const Prognostics& prognostics) {
                        std::string(")]");
   int_aero_species_ = SpeciesColumnView(int_view_name, num_aerosol_populations,
                                         num_vert_packs);
+  Kokkos::deep_copy(int_aero_species_, PackType(0));
   auto cld_view_name = std::string("d/dt[") +
                        prognostics.cloudborne_aerosols().label() +
                        std::string(")]");
   cld_aero_species_ = SpeciesColumnView(cld_view_name, num_aerosol_populations,
                                         num_vert_packs);
+  Kokkos::deep_copy(cld_aero_species_, PackType(0));
 
   int num_gases = prognostics.num_gases();
   auto gas_view_name = std::string("d/dt[") +
                        prognostics.gases().label() +
                        std::string(")]");
   gases_ = SpeciesColumnView(gas_view_name, num_gases, num_vert_packs);
+  Kokkos::deep_copy(gases_, PackType(0));
 
   auto n_view_name = std::string("d/dt[") +
                      prognostics.modal_num_concs().label() +
                      std::string(")]");
   int num_modes = prognostics.num_aerosol_modes();
   modal_num_concs_ = ModalColumnView(n_view_name, num_modes, num_vert_packs);
+  Kokkos::deep_copy(modal_num_concs_, PackType(0));
 }
 
 Tendencies::~Tendencies() {

--- a/haero/tests/mam_nucleation_fprocess_tests.cpp
+++ b/haero/tests/mam_nucleation_fprocess_tests.cpp
@@ -13,6 +13,8 @@ using namespace haero;
 using namespace haero;
 
 TEST_CASE("ternary_nuc_merik2007", "mam_nucleation_fprocess") {
+  using fp_helper = FloatingPoint<double>;
+  const double tolerance = 5.0e-09;
   /// Test the ternary_nuc_merik2007 function directly by calling both
   /// the original Fortran version and the new C++ version and compare
   /// the result. The testing process is to generate a bunch of random
@@ -46,11 +48,11 @@ TEST_CASE("ternary_nuc_merik2007", "mam_nucleation_fprocess") {
     double r_f90    = 0;
     MAMNucleationProcess::ternary_nuc_merik2007(t, rh, c2, c3, j_log_cpp, ntot_cpp, nacid_cpp, namm_cpp, r_cpp);
     ternary_nuc_merik2007_bridge(t, rh, c2, c3, j_log_f90, ntot_f90, nacid_f90, namm_f90, r_f90);
-    REQUIRE(j_log_cpp == j_log_f90);
-    REQUIRE(ntot_cpp  == ntot_f90);
-    REQUIRE(nacid_cpp == nacid_f90);
-    REQUIRE(namm_cpp  == namm_f90);
-    REQUIRE(r_cpp     == r_f90);
+    REQUIRE( fp_helper::equiv(j_log_cpp , j_log_f90, tolerance));
+    REQUIRE( fp_helper::equiv(ntot_cpp  , ntot_f90,  tolerance));
+    REQUIRE( fp_helper::equiv(nacid_cpp , nacid_f90, tolerance));
+    REQUIRE( fp_helper::equiv(namm_cpp  , namm_f90,  tolerance));
+    REQUIRE( fp_helper::equiv(r_cpp     , r_f90,     tolerance));
   }
 }
 
@@ -61,7 +63,6 @@ TEST_CASE("binary_nuc_vehk2002", "mam_nucleation_fprocess") {
   /// input values and check the output values are close.  Differences
   /// in Fortran and C++ means the result is not identical but we hope
   /// it is within numerical round off.
-
   using fp_helper = FloatingPoint<double>;
   const double abs_tol = 2.0e-12;
   const double rel_tol = 2.0e-12;
@@ -166,7 +167,7 @@ TEST_CASE("mer07_veh02_nuc_mosaic_1box", "mam_nucleation_fprocess") {
 
   using fp_helper = FloatingPoint<double>;
   const double abs_tol = 5.0e-12;
-  const double rel_tol = 5.0e-12;
+  const double rel_tol = 5.0e-09;
   // Define a pseudo-random generator [0-1) that is consistent across platforms.
   // Manually checked the first 100,000 values to be unique.
   const unsigned p0  = 987659;
@@ -299,7 +300,6 @@ TEST_CASE("mer07_veh02_nuc_mosaic_1box", "mam_nucleation_fprocess") {
 
 // These tests exercise our transplant of the MAM nucleation process.
 TEST_CASE("MAMNucleationFProcess", "mam_nucleation_fprocess") {
-
   // We create a phony model to be used for these tests.
   auto aero_config = create_mam4_modal_aerosol_config();
   int num_levels = 72;


### PR DESCRIPTION
The AerosolSpecies had a serious bug
where the copy constructor and assignment
operator did not copy the whole class.
This was a bug introduced when string
was replaced by char[] and the default
constructor and assignment had to be
replaced. For some reason the regression
tests passed for the GCC compile.

Also needed to increase the tolerances
a bit to get to pass for an Intel build.
Note: using Intel-19.0.5