### PR TITLE
Update mode tests to leverage new API

### DIFF
--- a/haero/tests/mode_tests.cpp
+++ b/haero/tests/mode_tests.cpp
@@ -14,31 +14,33 @@ using namespace haero;
 /// - min_vol_to_num_ratio
 /// - max_vol_to_num_ratio
 TEST_CASE("mode_ctor", "") {
+  // Set constants
+  static constexpr Real min_diameter = 8.7e-9;
+  static constexpr Real max_diameter = 5.2e-8;
+  static constexpr Real mean_std_dev = 1.6;
+  static constexpr Real crystallization_pt = 0.35;
+  static constexpr Real deliquescence_pt = 0.8;
+
   // Create a representation of the Aitken mode.
-  Mode aitken("Aitken", /*min_diameter=*/8.7e-9, /*max_diameter=*/5.2e-8,
-              /*mean_std_dev=*/1.6, /*crystallization_pt=*/0.35,
-              /*deliquescence_pt=*/0.8);
+  Mode aitken("Aitken", min_diameter, max_diameter, mean_std_dev,
+              crystallization_pt, deliquescence_pt);
   REQUIRE(aitken.name() == "Aitken");
-  REQUIRE(aitken.min_diameter == Real(8.7e-9));
-  REQUIRE(aitken.max_diameter == Real(5.2e-8));
-  REQUIRE(aitken.mean_std_dev == Real(1.6));
+  REQUIRE(aitken.min_diameter == Real(min_diameter));
+  REQUIRE(aitken.max_diameter == Real(max_diameter));
+  REQUIRE(aitken.mean_std_dev == Real(mean_std_dev));
 
   // Verify `mean_particle_volume_from_diameter` calculation
-  {
-    static constexpr Real geom_diam = 5.2e-8;
-    static constexpr Real mean_std_dev = 1.6;
-    REQUIRE(FloatingPoint<Real>::rel(
-        aitken.mean_particle_volume_from_diameter<Real>(geom_diam),
-        (constants::pi_sixth * cube(geom_diam) *
-         exp(4.5 * square(log(mean_std_dev)))),
-        5 * std::numeric_limits<Real>::epsilon()));
-  }
+  REQUIRE(FloatingPoint<Real>::rel(
+      aitken.mean_particle_volume_from_diameter<Real>(max_diameter),
+      (constants::pi_sixth * cube(max_diameter) *
+       exp(4.5 * square(log(mean_std_dev)))),
+      5 * std::numeric_limits<Real>::epsilon()));
 
   // Verify `min_vol_to_num_ratio` calculation
   {
     // compute min_vol_to_num ratio
     const Real comp_min_vol_to_num_ratio =
-        1 / aitken.mean_particle_volume_from_diameter<Real>(5.2e-8);
+        1 / aitken.mean_particle_volume_from_diameter<Real>(max_diameter);
 
     // compute relative difference for min_vol_to_num_ratio
     REQUIRE(FloatingPoint<Real>::rel(comp_min_vol_to_num_ratio,
@@ -50,7 +52,7 @@ TEST_CASE("mode_ctor", "") {
   {
     // compute max_vol_to_num ratio
     const Real comp_max_vol_to_num_ratio =
-        1 / aitken.mean_particle_volume_from_diameter<Real>(8.7e-9);
+        1 / aitken.mean_particle_volume_from_diameter<Real>(min_diameter);
 
     // compute relative difference for max_vol_to_num_ratio
     REQUIRE(FloatingPoint<Real>::rel(comp_max_vol_to_num_ratio,


### PR DESCRIPTION
`Mode` struct was updated with method `mean_particle_volume_from_diameter`, so
the tests were updated to reflect this.