### PR TITLE
Compy's Mode wet radius test fix

### DIFF
--- a/haero/tests/mode_wet_radius_tests.cpp
+++ b/haero/tests/mode_wet_radius_tests.cpp
@@ -56,8 +56,7 @@ TEST_CASE("wet_radius_diagnostic", "") {
   ColumnView relative_humidity("rel_humidity", npacks);
   auto h_relative_humidity = Kokkos::create_mirror_view(relative_humidity);
   const Real drelh =
-      (KohlerPoly::rel_humidity_max - KohlerPoly::rel_humidity_min) /
-      (nlev);
+      (KohlerPoly::rel_humidity_max - KohlerPoly::rel_humidity_min) / (nlev);
   for (int k = 0; k < nlev; ++k) {
     const int pack_idx = PackInfo::pack_idx(k);
     const int vec_idx = PackInfo::vec_idx(k);


### PR DESCRIPTION
`mode_wet_radius` test was failing on Compy. The reason was that the linearly interpolated relative humidity was touching the upper bound (`rhmax`). It is most likely due to the floating point calculations. I have temporarily fixed it by changing the denominator of the linear interpolation. This just ensures that `rh` is always less than `rhmax`.

@pbosler : If you know a better fix, I can use that to fix this.

Fixes #217