### PR TITLE
Fixing a int/size_t mismatch in mam_rename test.

### DIFF
--- a/haero/tests/mam_rename_fprocess_tests.cpp
+++ b/haero/tests/mam_rename_fprocess_tests.cpp
@@ -24,7 +24,7 @@ TEST_CASE("mam_rename_run", "") {
       aero_config.h_aerosol_modes.size()};  // number of modes
 
   // Set up some prognostics aerosol data views
-  const std::size_t num_aero_populations{model->num_aerosol_populations()};
+  const int num_aero_populations = model->num_aerosol_populations();
 
   Kokkos::View<PackType**> int_aerosols(
       "interstitial aerosols", num_aero_populations,


### PR DESCRIPTION
Just another irritating C++ `size_t`/`int` mismatch (we use `size_t` only to match the STL's `size()` return type).

Also, I personally prefer using assignment syntax to "struct-population" syntax for scalar types, because the latter looks foreign to non-CS folks. :-)