### PR TITLE
Fix mam_nucleation_process_tests for GPU.

### DIFF
--- a/haero/modal_aerosol_config.hpp
+++ b/haero/modal_aerosol_config.hpp
@@ -44,8 +44,11 @@ class ModalAerosolConfig final {
       const std::map<std::string, std::vector<std::string>>& mode_species,
       const std::vector<GasSpecies>& gas_species)
       : aerosol_modes(aerosol_modes),
+        aerosol_modes_size(aerosol_modes.size()),
         aerosol_species(aerosol_species),
+        aerosol_species_size(aerosol_species.size()),
         gas_species(gas_species),
+        gas_species_size(gas_species.size()),
         // Sum the length of all vectors in the mode_species map.
         // Is the use of std::accumulate here too obscure?
         num_aerosol_populations(std::accumulate(
@@ -73,22 +76,25 @@ class ModalAerosolConfig final {
 
   /// The list of aerosol modes associated with this aerosol model.
   std::vector<Mode> aerosol_modes;
+  int aerosol_modes_size;
 
   /// The list of all aerosol species associated with this aerosol model.
   std::vector<AerosolSpecies> aerosol_species;
+  int aerosol_species_size;
 
   /// The list of gas species associated with this aerosol model.
   std::vector<GasSpecies> gas_species;
+  int gas_species_size;
 
   /// The total number of distinct aerosol species populations in the
   /// model, counting appearances of one species in different modes separately.
   int num_aerosol_populations;
 
   KOKKOS_INLINE_FUNCTION
-  int num_modes() const { return aerosol_modes.size(); }
+  int num_modes() const { return aerosol_modes_size; }
 
   KOKKOS_INLINE_FUNCTION
-  int num_gases() const { return gas_species.size(); }
+  int num_gases() const { return gas_species_size; }
 
   inline int max_species_per_mode() const {
     int result = 0;

--- a/haero/processes/mam_calcsize_process.hpp
+++ b/haero/processes/mam_calcsize_process.hpp
@@ -37,7 +37,7 @@ class MAMCalcsizeProcess final
   KOKKOS_FUNCTION
   void run_(Real t, Real dt, const Prognostics &prognostics,
             const Atmosphere &atmosphere, const Diagnostics &diagnostics,
-            Tendencies &tendencies) const override{};
+            const Tendencies &tendencies) const override{};
 };
 
 }  // namespace haero

--- a/haero/processes/mam_nucleation_process.hpp
+++ b/haero/processes/mam_nucleation_process.hpp
@@ -188,6 +188,7 @@ class MAMNucleationProcess final
 
   /// Default copy constructor. For use in moving host instance to device.
   //  KOKKOS_INLINE_FUNCTION
+  KOKKOS_INLINE_FUNCTION
   MAMNucleationProcess(const MAMNucleationProcess &pp)
       : DeviceAerosolProcess<MAMNucleationProcess>(pp),
         adjust_factor_pbl_ratenucl(pp.adjust_factor_pbl_ratenucl),
@@ -196,10 +197,14 @@ class MAMNucleationProcess final
         iaer_nh3(pp.iaer_nh3),
         iaer_nh4(pp.iaer_nh4),
         iaer_so4(pp.iaer_so4),
+        dgnum_aer(pp.dgnum_aer),
+        dgnumlo_aer(pp.dgnumlo_aer),
+        dgnumhi_aer(pp.dgnumhi_aer),
         qgas_averaged_token(pp.qgas_averaged_token),
         uptkrate_h2so4_token(pp.uptkrate_h2so4_token),
         del_h2so4_gasprod_token(pp.del_h2so4_gasprod_token),
-        del_h2so4_aeruptk_token(pp.del_h2so4_aeruptk_token) {}
+        del_h2so4_aeruptk_token(pp.del_h2so4_aeruptk_token),
+        nait(pp.nait) {}
 
   /// MAMNucleationProcess objects are not assignable.
   AerosolProcess &operator=(const MAMNucleationProcess &) = delete;
@@ -214,7 +219,7 @@ class MAMNucleationProcess final
   KOKKOS_FUNCTION
   void run_(Real t, Real dt, const Prognostics &prognostics,
             const Atmosphere &atmosphere, const Diagnostics &diagnostics,
-            Tendencies &tendencies) const override {
+            const Tendencies &tendencies) const override {
     // First of all, check to make sure our model has an aitken mode. If it
     // doesn't, we can return immediately.
     if (nait == -1) {
@@ -450,6 +455,7 @@ class MAMNucleationProcess final
     Pack qnh3_cur(0.0);
     if (0 <= iaer_nh3) qnh3_cur = max(0.0, qgas_cur[iaer_nh3]);
     // dry-diameter limits for "grown" new particles
+
     const Real dplom_mode =
         exp(0.67 * log(dgnumlo_aer[nait]) + 0.33 * log(dgnum_aer[nait]));
     const Real dphim_mode = dgnumhi_aer[nait];

--- a/haero/processes/mam_rename_process.hpp
+++ b/haero/processes/mam_rename_process.hpp
@@ -23,7 +23,7 @@ class MAMRenameProcess final : public DeviceAerosolProcess<MAMRenameProcess> {
   KOKKOS_FUNCTION
   void run_(Real t, Real dt, const Prognostics &prognostics,
             const Atmosphere &atmosphere, const Diagnostics &diagnostics,
-            Tendencies &tendencies) const override {}
+            const Tendencies &tendencies) const override {}
 };
 
 }  // namespace haero

--- a/haero/tests/mam_nucleation_process_tests.cpp
+++ b/haero/tests/mam_nucleation_process_tests.cpp
@@ -177,8 +177,8 @@ TEST_CASE("pbl_nuc_wang2008", "mam_nucleation_process") {
     SolutionView solution("pbl_nuc_wang2008", 6);
     FlagaaView flags("newnuc_method_flagaa", 1);
 
-    auto device_ptr = static_cast<MAMNucleationProcess*>(
-        mam_nucleation_process.copy_to_device().get());
+    auto device_pp  = mam_nucleation_process.copy_to_device();
+    auto device_ptr = static_cast<MAMNucleationProcess*>(device_pp.get());
     Kokkos::parallel_for(
         "pbl_nuc_wang2008.mam_nucleation_process", 1, KOKKOS_LAMBDA(const int) {
           ekat::Pack<int, 1> flagaa2(0);
@@ -316,8 +316,8 @@ TEST_CASE("mer07_veh02_nuc_mosaic_1box", "mam_nucleation_process") {
     Kokkos::deep_copy(dplom_sect_view, h_dplom_sect_view);
     Kokkos::deep_copy(dphim_sect_view, h_dphim_sect_view);
 
-    auto device_ptr = static_cast<MAMNucleationProcess*>(
-        mam_nucleation_process.copy_to_device().get());
+    auto device_pp  = mam_nucleation_process.copy_to_device();
+    auto device_ptr = static_cast<MAMNucleationProcess*>(device_pp.get());
     Kokkos::parallel_for(
         "mer07_veh02_nuc_mosaic_1box.mam_nucleation_process", 1,
         KOKKOS_LAMBDA(const int) {
@@ -519,9 +519,20 @@ TEST_CASE("virtual_process_test", "mam_nucleation_process") {
     Kokkos::deep_copy(gases, h_gases);
 
     // Now compute the tendencies by running the process.
-    Real t = 0.0, dt = 30.0;
-    process->run(t, dt, *progs, *atm, *diags, *tends);
-
+    {
+      Real t = 0.0, dt = 30.0;
+      auto device_pp  = process->copy_to_device();
+      AerosolProcess *device_ptr = device_pp.get();
+      Prognostics  device_progs = *progs;
+      Atmosphere   device_atm   = *atm;
+      Diagnostics  device_diags = *diags; 
+      Tendencies   device_tends = *tends;
+      Kokkos::parallel_for(
+          "run.run", 1,
+          KOKKOS_LAMBDA(const int) {
+          device_ptr->run(t, dt, device_progs, device_atm, device_diags, device_tends);
+        });
+    }
     // --------------------------------------------------
     // Check the tendencies to make sure they make sense.
     // --------------------------------------------------
@@ -624,9 +635,20 @@ TEST_CASE("virtual_process_test", "mam_nucleation_process") {
     Kokkos::deep_copy(gases, h_gases);
 
     // Now compute the tendencies by running the process.
-    Real t = 0.0, dt = 30.0;
-    process->run(t, dt, *progs, *atm, *diags, *tends);
-
+    {
+      Real t = 0.0, dt = 30.0;
+      auto device_pp  = process->copy_to_device();
+      AerosolProcess *device_ptr = device_pp.get();
+      Prognostics  device_progs = *progs;
+      Atmosphere   device_atm   = *atm;
+      Diagnostics  device_diags = *diags; 
+      Tendencies   device_tends = *tends;
+      Kokkos::parallel_for(
+          "run.run", 1,
+          KOKKOS_LAMBDA(const int) {
+          device_ptr->run(t, dt, device_progs, device_atm, device_diags, device_tends);
+        });
+    }
     // --------------------------------------------------
     // Check the tendencies to make sure they make sense.
     // --------------------------------------------------

--- a/haero/tests/process_tests.cpp
+++ b/haero/tests/process_tests.cpp
@@ -45,7 +45,7 @@ class MyAerosolProcess final : public DeviceAerosolProcess<MyAerosolProcess> {
   KOKKOS_FUNCTION
   void run_(Real t, Real dt, const Prognostics &prognostics,
             const Atmosphere &atmosphere, const Diagnostics &diagnostics,
-            Tendencies &tendencies) const {
+            const Tendencies &tendencies) const {
     const SpeciesColumnView int_aerosols = prognostics.interstitial_aerosols;
     const ColumnView temp = atmosphere.temperature;
     const SpeciesColumnView first_aersol = diagnostics.aerosol_var(aersol_0);


### PR DESCRIPTION
(1) Changed the calling signature for the process run() function. Before
the prognostic class was non-const since prognostics are updated
during a process.  But Kokkos lambdas capture as const so the
class needs to be passed by const.  This is OK since everything in
the prognostic class that is updated is a Kokkos View and Kokkos
allows const views to be updated.

(2) Extended the custom deleter used in the copy_to_device() shared
pointer to call the destructor on the base class before calling
kokkos to free the allocated memory.