### PR TITLE
Using the correct variant of workflow

### DIFF
--- a/.github/workflows/push_mirror.yml
+++ b/.github/workflows/push_mirror.yml
@@ -5,11 +5,13 @@ on: [push, delete]
 jobs:
   to_gitlab:
     runs-on: ubuntu-18.04
-    steps:                                              # <-- must use actions/checkout@v1 before mirroring!
-    - uses: actions/checkout@v1
-    - uses: pixta-dev/repository-mirroring-action@v1
-      with:
-        target_repo_url:
-          ssh://git@gitlab.pnnl.gov:2222/eagles/haero-ci-mirror.git
-        ssh_private_key:                                # <-- use 'secrets' to pass credential information.
-          ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: spyoungtech/mirror-action@master
+        with:
+          REMOTE: ${{ secrets.GIT_REPO_URL }}
+          GIT_USERNAME: ${{ secrets.GIT_USER }}
+          GIT_PASSWORD: ${{ secrets.GIT_PASSWORD }}
+          GIT_PUSH_ARGS: --push-option=ci.skip --tags --force --prune
+      - uses: nelonoel/branch-name@v1.0.1
+      - run: curl -X POST -F token=${{ secrets.PNNL_PIPELINE_TRIGGER_TOKEN }} -F ref=${BRANCH_NAME} https://gitlab.pnnl.gov/api/v4/projects/1056/trigger/pipeline


### PR DESCRIPTION
This should have been the correct implementation. Please change the Vault Environment variables to reflect:
GIT_REPO_URL - https clone URL
GIT_USER - Service Account generated with the Project Access Token
GIT_PASSWORD - Project Access Token from GitLab
PNNL_PIPELINE_TRIGGER_TOKEN - Generated pipeline trigger token in the Settings>>CI/CD>>Pipeline triggers

closes #271 