### PR TITLE
Bug fix: haero now links against spdlog

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -468,6 +468,7 @@ if (${EKAT_LIBRARY_DIR} MATCHES ${PROJECT_BINARY_DIR}) # we built ekat
   install(FILES       ${EKAT_LIBRARY}
                       ${EKAT_LIBRARY_DIR}/libekat_test_main.a
                       ${EKAT_LIBRARY_DIR}/libekat_test_session.a
+                      ${EKAT_LIBRARY_DIR}/libspdlog.a
                       ${EKAT_LIBRARY_DIR}/libkokkoscore.a
                       ${EKAT_LIBRARY_DIR}/libkokkoscontainers.a
           DESTINATION lib)


### PR DESCRIPTION
Without this, we can't use `ekat::logger`.