### PR TITLE
Replaces ierr with 1 in stop statements in rename.F90

### DIFF
--- a/haero/processes/mam_rename.F90
+++ b/haero/processes/mam_rename.F90
@@ -45,7 +45,7 @@ contains
     allocate(population_offsets(num_modes), stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not allocate population_offsets with length ', num_modes
-      stop ierr
+      stop 1
     endif
     population_offsets(:) = model%population_offsets(:)
 
@@ -281,19 +281,19 @@ subroutine compute_dryvol_change_in_src_mode(num_modes, dest_mode_of_mode, &
     allocate(dgnumlo_aer(num_modes), stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not allocate dgnumlo_aer with length ', num_modes
-      stop ierr
+      stop 1
     endif
 
     allocate(dgnumhi_aer(num_modes), stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not allocate dgnumhi_aer with length ', num_modes
-      stop ierr
+      stop 1
     endif
 
     allocate(dgnum_aer(num_modes), stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not allocate dgnum_aer with length ', num_modes
-      stop ierr
+      stop 1
     endif
 
     ! Initialize min and max diameters
@@ -317,25 +317,25 @@ subroutine compute_dryvol_change_in_src_mode(num_modes, dest_mode_of_mode, &
     deallocate(dgnumlo_aer, stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not deallocate dgnumlo_aer'
-      stop ierr
+      stop 1
     endif
 
     deallocate(dgnumhi_aer, stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not deallocate dgnumhi_aer'
-      stop ierr
+      stop 1
     endif
 
     deallocate(dgnum_aer, stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not deallocate dgnum_aer'
-      stop ierr
+      stop 1
     endif
 
     deallocate(population_offsets, stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not deallocate population_offsets'
-      stop ierr
+      stop 1
     endif
 
   end subroutine finalize_diameters
@@ -353,7 +353,7 @@ subroutine compute_dryvol_change_in_src_mode(num_modes, dest_mode_of_mode, &
     allocate(alnsg(num_modes), stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not allocate alnsg with length ', num_modes
-      stop ierr
+      stop 1
     endif
 
     alnsg(:) = log(model%modes(:)%mean_std_dev)
@@ -372,7 +372,7 @@ subroutine compute_dryvol_change_in_src_mode(num_modes, dest_mode_of_mode, &
     deallocate(alnsg, stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not deallocate alnsg'
-      stop ierr
+      stop 1
     endif
 
   end subroutine finalize_ln_of_std_dev


### PR DESCRIPTION
Intel compiler on Compy doesn't like `stop ierr` statements if `ierr` is a variable. `ierr` is replaced by 1 in all the statements to avoid this error.

Partly addresses #289 