### PR TITLE
Set Real to double in chem_driver

### DIFF
--- a/chem_driver/chem_driver.hpp
+++ b/chem_driver/chem_driver.hpp
@@ -17,7 +17,6 @@ namespace chem_driver {
 
 // some aliases
 using ordinal_type = TChem::ordinal_type;
-using Real = haero::Real;
 using real_type_1d_view = TChem::real_type_1d_view;
 using real_type_2d_view = TChem::real_type_2d_view;
 using policy_type = typename TChem::UseThisTeamPolicy<TChem::exec_space>::type;
@@ -157,7 +156,7 @@ class ChemSolver {
 // implementation of the toy problem
 namespace from_tchem {
 
-using Real = haero::Real;
+using Real = double;
 
 struct SourceTermToyProblem {
   template <typename KineticModelConstDataType>


### PR DESCRIPTION
This closes #276 by imposing double precision for the chem driver. For now, I've just set the Real alias to double.

This isn't the clearest change, from a readability standpoint, at this time, but my other branch for the fancy new TChem changes almost every file in a major way. So, on that branch I intend to use double, rather than hiding it behind an alias that doesn't line up with its usage in the rest of Haero.

Everything builds and passes for single, and builds for double. However, I am seeing a unit test failure referenced in #311.