### PR TITLE
Switching to a safer method of syncing submodules.

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Checking out repository
       uses: actions/checkout@v2
       with:
-        token: ${{ secrets.ACCESS_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         submodules: recursive
 
     - name: Configuring haero (${{ matrix.build-type }}, ${{ matrix.fp-precision }} precision, pack size=${{ matrix.pack-size }})


### PR DESCRIPTION
Haero uses git submodules to maintain its third-party libraries. Because we use the SSH protocol for submodules, which allows us to edit the source for these libraries right in Haero's repository, we must use an access token to authenticate against the various submodules. In particular, we must have an access token that is dedicated to our auto-testing environment, or we can't clone the submodules when these tests are run for a pull request.

This tiny PR switches us from the "personal access token" I've been using to a special access token that GitHub provides for cloning submodules. The token is created when the autotester starts, and deleted when it ends. You can't get much more secure than that.