### PR TITLE
Fixes an allocation bug producing a seg fault in the MAM rename Fortran process.

### DIFF
--- a/haero/processes/mam_rename.F90
+++ b/haero/processes/mam_rename.F90
@@ -42,7 +42,7 @@ contains
     num_modes = config%num_modes
     num_populations = config%num_populations
 
-    allocate(population_offsets(num_modes), stat=ierr)
+    allocate(population_offsets(num_modes+1), stat=ierr)
     if (ierr .ne. 0) then
       print *, 'Could not allocate population_offsets with length ', num_modes
       stop 1


### PR DESCRIPTION
I think this should fix the crash we're seeing in the MAM Fortran rename process test. There's still work left to do in this process's Fortran implementation, though.

Let me know if you still get that intermittent crash with this fix.

Fixes #311 
