### PR TITLE
Fixed a bug in the population of aerosol species in Fortran.

### DIFF
--- a/haero/aerosol_process.cpp
+++ b/haero/aerosol_process.cpp
@@ -113,9 +113,9 @@ void AerosolProcess::init_fortran_(const ModalAerosolConfig& config) {
                                mode.deliquescence_pt, mode.crystallization_pt);
 
     // Set up aerosol species for this mode.
-    int num_species = mode_species.size();
-    for (int s = 0; s < num_species; ++s) {
-      const auto species = config_->aerosol_species[s];
+    int num_aero_species = mode_species.size();
+    for (int s = 0; s < num_aero_species; ++s) {
+      const auto species = mode_species[s];
       haerotran_set_aerosol_species(
           m + 1, s + 1, species.name().c_str(), species.symbol().c_str(),
           species.molecular_weight, species.density, species.hygroscopicity);


### PR DESCRIPTION
@singhbalwinder  identified a bug in the aerosol species metadata within the
calcsize process. It turns out we were reading species data from an
array that had the species in the wrong order. This is now fixed.