### PR TITLE
Fortran 90 validation programs now link using the Fortran compiler.

### DIFF
--- a/validation/nucleation/CMakeLists.txt
+++ b/validation/nucleation/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(${PROJECT_BINARY_DIR}/validation)
 add_executable(nucleation_rate nucleation_rate.cpp)
 target_link_libraries(nucleation_rate skywalker;validation;${HAERO_LIBRARIES})
 add_executable(nucleation_rate_f90 nucleation_rate.F90)
+set_target_properties(nucleation_rate_f90 PROPERTIES LINKER_LANGUAGE Fortran)
 target_link_libraries(nucleation_rate_f90 skywalker_f90;validation_f90;${HAERO_LIBRARIES})
 
 # This driver computes the threshold concentration of H2SO4 at given T and RH
@@ -15,6 +16,7 @@ target_link_libraries(nucleation_rate_f90 skywalker_f90;validation_f90;${HAERO_L
 add_executable(nucleation_thresh nucleation_thresh.cpp)
 target_link_libraries(nucleation_thresh skywalker;validation;${HAERO_LIBRARIES})
 add_executable(nucleation_thresh_f90 nucleation_thresh.F90)
+set_target_properties(nucleation_thresh_f90 PROPERTIES LINKER_LANGUAGE Fortran)
 target_link_libraries(nucleation_thresh_f90 skywalker_f90;validation_f90;${HAERO_LIBRARIES})
 
 # This driver computes the growth SO4 and NH4 aerosol particeles from


### PR DESCRIPTION
This addresses an issue that @singhbalwinder discovered while building the new nucleation validation drivers on Compy.