### PR TITLE
Added nom_vol_to_num_ratio method to C++ Mode class.

### DIFF
--- a/haero/mode.hpp
+++ b/haero/mode.hpp
@@ -189,7 +189,8 @@ struct Mode final {
   template <typename T>
   KOKKOS_INLINE_FUNCTION T nom_vol_to_num_ratio() const {
     const Real pio6 = Constants::pi_sixth;
-    return 1 / pio6 * cube(nom_diameter) * exp(4.5 * (log(mean_std_dev)));
+    return 1 /
+           (pio6 * cube(nom_diameter) * exp(4.5 * square(log(mean_std_dev))));
   }
 
   // Comparison operators.

--- a/haero/tests/mode_tests.cpp
+++ b/haero/tests/mode_tests.cpp
@@ -66,8 +66,8 @@ TEST_CASE("mode_ctor", "") {
   {
     // compute nom_vol_to_num ratio
     const Real comp_nom_vol_to_num_ratio =
-        1 / Constants::pi_sixth * cube(aitken.nom_diameter) *
-        exp(4.5 * (log(aitken.mean_std_dev)));
+        1 / (Constants::pi_sixth * cube(aitken.nom_diameter) *
+             exp(4.5 * square(log(aitken.mean_std_dev))));
 
     // compute relative difference for nom_vol_to_num_ratio
     REQUIRE(FloatingPoint<Real>::rel(comp_nom_vol_to_num_ratio,


### PR DESCRIPTION
This adds a missing method to the C++ mode class that was added to its Fortran counterpart.