### PR TITLE
updates to README to reflect transition to mkdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,14 @@ documentation, you must download `mkdocs` and its Material theme:
 Then, run `mkdocs serve` from the root directory of your Haero repo,
 and point your browser to [`http://localhost:8000`](http://localhost:8000).
 
-Haero's documentation includes
+Haero's documentation includes:
 
 * an extensive design document.
-This document describes the aerosol modeling
-methodology used by Haero, as well as the library itself, and its various
-representations of aerosol processes
+This document describes the aerosol modeling methodology used by Haero,
+as well as the library itself, and its various representations of aerosol processes.
 
 * documentation for Haero's C++/Fortran API, found at
-[`Library/Fortran aerosol processes`]
-(http://localhost:8000/library/#fortran-aerosol-processes).
+[`Library/Fortran aerosol processes`](http://localhost:8000/library/#fortran-aerosol-processes).
 
 # FAQ
 


### PR DESCRIPTION
Here's a draft update to the front page README to explain how to use the new docs and what it contains. The description of contents was more or less just copy/pasted from the original description of the latex doc, so it may need updating.