### PR TITLE
Fixing broken libdl search.

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -29,10 +29,7 @@ if (HAERO_ENABLE_DRIVER)
 # Dynamic loading library
 #----------------------------------------------------------------------------
 if (NOT APPLE)
-  find_library(DL_LIBRARY libdl${CMAKE_SHARED_LIBRARY_SUFFIX} REQUIRED)
-  add_library(dl SHARED IMPORTED GLOBAL)
-  set_target_properties(dl PROPERTIES IMPORTED_LOCATION ${DL_LIBRARY})
-  set(HAERO_EXT_LIBRARIES dl) # Required by kokkoscore.
+  set(HAERO_EXT_LIBRARIES ${CMAKE_DL_LIBS}) # Required by kokkoscore.
 endif()
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
A recent Linux upgrade resulted in CMake not being able to find libdl.so, which is needed by the Kokkos core library. This PR fixes the library search "the CMake way".