### PR TITLE
🔧Fix DL libs passed to netcdf submodule

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -139,7 +139,7 @@ if (NOT EXISTS ${NETCDF_LIBRARY})
                         -DHDF5_INCLUDE_DIR=${HDF5_INCLUDE_DIR}
                         -DZLIB_LIBRARY=${ZLIB_LIBRARIES}
                         -DHAVE_LIBDL=ON
-                        -DLIBDL=${DL_LIBRARY}
+                        -DLIBDL=${CMAKE_DL_LIBS}
                         -DENABLE_PARALLEL=${HAVE_MPI}
                         -DHDF5_IS_PARALLEL=${HAVE_MPI}
                         -DHDF5_IS_PARALLEL_MPIO=${HAVE_MPI}


### PR DESCRIPTION
Failed to build from latest main, I believe this should fix the issue. In the same spirit as #353.