### PR TITLE
fix tchem dependency for chem_driver

### DIFF
--- a/chem_driver/CMakeLists.txt
+++ b/chem_driver/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${HAERO_INCDIRS} ${CHEM_DRIVER_INCDIRS})
 
 add_library(chem_standalone chem_driver.cpp)
 
-add_dependencies(chem_standalone haero yaml_cpp)
+add_dependencies(chem_standalone haero yaml_cpp tchem)
 
 install(TARGETS chem_standalone DESTINATION lib)
 


### PR DESCRIPTION
Not sure how this one snuck through, or why it never crashed builds before. But here's a fix for an issue I encountered!