### PR TITLE
Add Kokkos Cuda compile flags to sources in libhero.a

### DIFF
--- a/haero/CMakeLists.txt
+++ b/haero/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(haero
             utils.cpp
             view_pack_helpers.cpp)
 add_dependencies(haero ext_libraries update_version_info)
+target_compile_options(haero PRIVATE  $<$<COMPILE_LANGUAGE:CXX>:${KOKKOS_CUDA_OPTIONS}>)
 if (HAERO_ENABLE_CHEMISTRY)
   add_dependencies(haero tchem)
 endif()


### PR DESCRIPTION
The compiles of these few sources were missing the -arch=sm_70
or similar flag which resulted in a warning. Specifying the
arch flag allows the Cuda compiler to just compile down to
the target architecture.