### PR TITLE
Remove adding optimization options to the compiler flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,6 @@ else()
 endif ()
 
 # C++ compiler flags.
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RelWithDebInfo "-g -O2 -DNDEBUG")
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")


### PR DESCRIPTION
When these flags are added there are two different optimizations
on the compile lines for a Release build, -O2 and -O3.
This causes a compiler warning.

Removing the flags does not eliminate the warning because
ekat also adds flags but now the warning is about the same
flag, -O3, appearing twice which is a step in the right direction.