### PR TITLE
add new root finder header to install list

### DIFF
--- a/haero/CMakeLists.txt
+++ b/haero/CMakeLists.txt
@@ -67,5 +67,6 @@ install(FILES aero_process.hpp
               math.hpp
               utils.hpp
               view_pack_helpers.hpp
+              root_finders.hpp
         DESTINATION include/haero)
 


### PR DESCRIPTION
Shrunk old `math.hpp` by splitting into 3 new headers.  One of them needs to be installed so that mam4xx can see it.  This PR installs it.