### PR TITLE
Minor touch-ups (C++ formatting rules, new machine file)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,2 @@
 ---
-BasedOnStyle: Google
+BasedOnStyle: LLVM

--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -75,11 +75,6 @@ jobs:
 #          -DTCHEM_LIBRARY=/opt/haero/lib/libtchem.a \
 #          -DTCHEM_INCLUDE_DIR=/opt/haero/include \
 
-    - name: Checking C++ code formatting...
-      run: |
-        cd build
-        make format-cxx-check
-
     - name: Building haero (${{ matrix.build-type }}, ${{ matrix.fp-precision }} precision)
       run: |
         cd build

--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -22,9 +22,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-#    # Pre-fab container with third-party libs installed.
-#    container: coherellc/haero-tpl:${{ matrix.build-type }}-${{ matrix.fp-precision }}
-
     # Environment variables
     env:
       FC: gfortran
@@ -78,11 +75,10 @@ jobs:
 #          -DTCHEM_LIBRARY=/opt/haero/lib/libtchem.a \
 #          -DTCHEM_INCLUDE_DIR=/opt/haero/include \
 
-# TODO: clang-format seems unstable under different versions. Not helpful!
-#    - name: Checking code formatting...
-#      run: |
-#        cd build
-#        make format-cxx-check
+    - name: Checking C++ code formatting...
+      run: |
+        cd build
+        make format-cxx-check
 
     - name: Building haero (${{ matrix.build-type }}, ${{ matrix.fp-precision }} precision)
       run: |

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,13 @@
+name: clang-format Check
+on: [pull_request]
+jobs:
+  formatting-check:
+    name: C++ formatting check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check C++ formatting
+      uses: jidicula/clang-format-action@v4.9.0
+      with:
+        clang-format-version: '14'
+        check-path: 'haero'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,11 +274,11 @@ if (NOT CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")
       "Please make sure this version appears in your path and rerun config.sh.")
   else()
     add_custom_target(format-cxx
-      find ${PROJECT_SOURCE_DIR}/src -name "*.[hc]pp" -exec ${CLANG_FORMAT} -i {} \+;
+      find ${PROJECT_SOURCE_DIR}/haero -name "*.[hc]pp" -exec ${CLANG_FORMAT} -i {} \+;
       VERBATIM
       COMMENT "Auto-formatting C++ code...")
     add_custom_target(format-cxx-check
-      find ${PROJECT_SOURCE_DIR}/src -name "*.[hc]pp" -exec ${CLANG_FORMAT} -n --Werror -ferror-limit=1 {} \+;
+      find ${PROJECT_SOURCE_DIR}/haero -name "*.[hc]pp" -exec ${CLANG_FORMAT} -n --Werror -ferror-limit=1 {} \+;
       VERBATIM
       COMMENT "Checking C++ formatting...")
   endif()

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ workstation. We also support a limited number of platforms on which the Haero
 model is built and tested:
 
 * NERSC Cori
-* Compy and Constance at PNNL
+* Compy, Constance, Deception at PNNL
 
 ## Required Software
 
@@ -61,7 +61,9 @@ To configure Haero:
    ./setup build
    ```
 3. Change to your build directory and edit the `config.sh` file to select
-   configuration options. Then run `./config.sh` to configure the model.
+   configuration options. Then execute `config.sh` to configure the model.
+   If you're on a machine that requires modules to get access to compilers, etc,
+   use `source config.sh` to make sure your environment is updated.
 4. From the build directory, type `make -j` to build the library. (If you've
    configured your build for a GPU, place a number after the `-j` flag, as in
    `make -j 8`).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,13 +54,19 @@ appropriate options set.
 
 To configure Haero:
 
-1. Create a build directory by running the `setup` script from the top-level
+1. Make sure you have the latest versions of all the required submodules:
+   ```
+   git submodule update --init --recursive
+   ```
+2. Create a build directory by running the `setup` script from the top-level
    source directory:
    ```
    ./setup build
    ```
-2. Change to your build directory and edit the `config.sh` file to select
-   configuration options. Then run `./config.sh` to configure the model.
+3. Change to your build directory and edit the `config.sh` file to select
+   configuration options. Then run `source config.sh` to configure the model
+   (this ensures that any settings by machine-specific scripts stick around in
+   your environment).
 
 If you prefer, you can fish the options out of the `setup` script (or your
 generated `config.sh` file) and feed them directly to CMake.

--- a/haero/aero_process.hpp
+++ b/haero/aero_process.hpp
@@ -3,8 +3,8 @@
 
 #include <haero/atmosphere.hpp>
 
-#include <memory>
 #include <cstring>
+#include <memory>
 #include <type_traits>
 
 namespace haero {
@@ -15,27 +15,26 @@ namespace haero {
 /// defined by a specific "aerosol configuration".
 template <typename AerosolConfig, typename AerosolProcessImpl>
 class AeroProcess final {
- public:
-
+public:
   // Types derived from template parameters.
-  using AeroConfig    = AerosolConfig;
-  using Prognostics   = typename AerosolConfig::Prognostics;
-  using Diagnostics   = typename AerosolConfig::Diagnostics;
-  using Tendencies    = typename AerosolConfig::Tendencies;
-  using ProcessImpl   = AerosolProcessImpl;
+  using AeroConfig = AerosolConfig;
+  using Prognostics = typename AerosolConfig::Prognostics;
+  using Diagnostics = typename AerosolConfig::Diagnostics;
+  using Tendencies = typename AerosolConfig::Tendencies;
+  using ProcessImpl = AerosolProcessImpl;
   using ProcessConfig = typename ProcessImpl::Config;
 
   // Tendencies type must be the same as that for Prognostics.
   static_assert(std::is_same<Tendencies, Prognostics>::value,
-    "Tendencies and Prognostics types must be identical!");
+                "Tendencies and Prognostics types must be identical!");
 
   /// Constructs an instance of an aerosol process with the given name,
   /// associated with the given aerosol configuration.
   /// @param [in] aero_config The aerosol configuration for this process
   /// @param [in] process_config Any process-specific information required by
   ///                            this process's implementation.
-  AeroProcess(const AeroConfig& aero_config,
-              const ProcessConfig& process_config = ProcessConfig())
+  AeroProcess(const AeroConfig &aero_config,
+              const ProcessConfig &process_config = ProcessConfig())
       : aero_config_(aero_config), process_config_(process_config),
         process_impl_() {
     // Set the name of this process.
@@ -50,13 +49,13 @@ class AeroProcess final {
 
   // Copy construction is required for host -> device dispatches
   KOKKOS_INLINE_FUNCTION
-  AeroProcess(const AeroProcess&) = default;
+  AeroProcess(const AeroProcess &) = default;
 
   /// Default constructor is disabled.
   AeroProcess() = delete;
 
   // Deep copies are not allowed.
-  AeroProcess& operator=(const AeroProcess&) = delete;
+  AeroProcess &operator=(const AeroProcess &) = delete;
 
   //------------------------------------------------------------------------
   //                          Accessors (host only)
@@ -67,14 +66,10 @@ class AeroProcess final {
 
   /// On host: returns the aerosol configuration (metadata) associated with
   /// this process.
-  const AeroConfig& aero_config() const {
-    return aero_config_;
-  }
+  const AeroConfig &aero_config() const { return aero_config_; }
 
   /// On host: returns any process-specific configuration data.
-  const ProcessConfig& process_config() const {
-    return process_config_;
-  }
+  const ProcessConfig &process_config() const { return process_config_; }
 
   //------------------------------------------------------------------------
   //                            Public Interface
@@ -89,9 +84,8 @@ class AeroProcess final {
   /// @param [in] prognostics A collection of aerosol prognostic variables to be
   ///                         validated.
   KOKKOS_INLINE_FUNCTION
-  bool validate(const ThreadTeam& team,
-                const Atmosphere& atmosphere,
-                const Prognostics& prognostics) const {
+  bool validate(const ThreadTeam &team, const Atmosphere &atmosphere,
+                const Prognostics &prognostics) const {
     return process_impl_.validate(aero_config_, team, atmosphere, prognostics);
   }
 
@@ -112,22 +106,22 @@ class AeroProcess final {
   /// @param [out]   tendencies An array analogous to prognostics that
   ///                           stores computed tendencies.
   KOKKOS_INLINE_FUNCTION
-  void compute_tendencies(const ThreadTeam& team, Real t, Real dt,
-                          const Atmosphere& atmosphere,
-                          const Prognostics& prognostics,
-                          const Diagnostics& diagnostics,
-                          const Tendencies& tendencies) const {
+  void compute_tendencies(const ThreadTeam &team, Real t, Real dt,
+                          const Atmosphere &atmosphere,
+                          const Prognostics &prognostics,
+                          const Diagnostics &diagnostics,
+                          const Tendencies &tendencies) const {
     process_impl_.compute_tendencies(aero_config_, team, t, dt, atmosphere,
                                      prognostics, diagnostics, tendencies);
   }
 
- private:
-  char          name_[256];
-  AeroConfig    aero_config_;
+private:
+  char name_[256];
+  AeroConfig aero_config_;
   ProcessConfig process_config_;
-  ProcessImpl   process_impl_;
+  ProcessImpl process_impl_;
 };
 
-}  // namespace haero
+} // namespace haero
 
 #endif

--- a/haero/aero_species.hpp
+++ b/haero/aero_species.hpp
@@ -23,6 +23,6 @@ struct AeroSpecies final {
   const Real hygroscopicity;
 };
 
-}  // namespace haero
+} // namespace haero
 
 #endif

--- a/haero/aero_utils.hpp
+++ b/haero/aero_utils.hpp
@@ -8,8 +8,7 @@ namespace haero {
 /// @struct AeroUtils
 /// This is just a grab bag of utility functions that work with an aerosol
 /// package with the given configuration type.
-template <typename AeroConfig>
-struct AeroUtils final {
+template <typename AeroConfig> struct AeroUtils final {
 
   // Types derived from template parameters.
   using Config = AeroConfig;
@@ -17,7 +16,7 @@ struct AeroUtils final {
 
   // You can't create one of these classes--it's just a templated namespace.
   AeroUtils() = delete;
-  AeroUtils(const AeroUtils&) = delete;
+  AeroUtils(const AeroUtils &) = delete;
   ~AeroUtils() = delete;
 
   /// On host: calls a given function, passing it each of the mass mixing ratios
@@ -27,8 +26,8 @@ struct AeroUtils final {
   /// @param [in] f The function to be called with the given arguments. Usually
   ///               f is a lambda that is allowed to capture values from the
   ///               call site.
-  static void foreach_aero_mmr(const Config& config,
-                               std::function<void(const AeroMD&)> f) {
+  static void foreach_aero_mmr(const Config &config,
+                               std::function<void(const AeroMD &)> f) {
     config.foreach_aero_mmr(f);
   }
 
@@ -39,8 +38,8 @@ struct AeroUtils final {
   /// @param [in] f The function to be called with the given arguments. Usually
   ///               f is a lambda that is allowed to capture values from the
   ///               call site.
-  static void foreach_aero_nmr(const Config& config,
-                               std::function<void(const AeroMD&)> f) {
+  static void foreach_aero_nmr(const Config &config,
+                               std::function<void(const AeroMD &)> f) {
     config.foreach_aero_nmr(f);
   }
 
@@ -51,11 +50,10 @@ struct AeroUtils final {
   /// @param [in] f The function to be called with the given arguments. Usually
   ///               f is a lambda that is allowed to capture values from the
   ///               call site.
-  static void foreach_gas(const Config& config,
-                          std::function<void(const GasSpecies&)> f) {
+  static void foreach_gas(const Config &config,
+                          std::function<void(const GasSpecies &)> f) {
     config.foreach_gas(f);
   }
-
 };
 
 } // namespace haero

--- a/haero/atmosphere.cpp
+++ b/haero/atmosphere.cpp
@@ -5,13 +5,11 @@
 namespace haero {
 
 Atmosphere::Atmosphere(int num_levels, Real pblh)
-    : temperature("temperature", num_levels),
-      pressure("pressure", num_levels),
+    : temperature("temperature", num_levels), pressure("pressure", num_levels),
       vapor_mixing_ratio("vapor mixing ratio", num_levels),
       height("height", num_levels),
       hydrostatic_dp("hydrostatic_dp", num_levels),
-      planetary_boundary_height(pblh),
-      num_levels_(num_levels) {
+      planetary_boundary_height(pblh), num_levels_(num_levels) {
   EKAT_REQUIRE_MSG(num_levels > 0,
                    "Number of vertical levels must be positive");
   EKAT_REQUIRE_MSG(pblh >= 0.0,
@@ -21,12 +19,8 @@ Atmosphere::Atmosphere(int num_levels, Real pblh)
 Atmosphere::Atmosphere(int num_levels, const ColumnView temp,
                        const ColumnView press, const ColumnView qv,
                        const ColumnView ht, const ColumnView pdel, Real pblh)
-    : temperature(temp),
-      pressure(press),
-      vapor_mixing_ratio(qv),
-      height(ht),
-      hydrostatic_dp(pdel),
-      planetary_boundary_height(pblh),
+    : temperature(temp), pressure(press), vapor_mixing_ratio(qv), height(ht),
+      hydrostatic_dp(pdel), planetary_boundary_height(pblh),
       num_levels_(num_levels) {
   EKAT_REQUIRE_MSG(num_levels > 0,
                    "Number of vertical levels must be positive");
@@ -48,4 +42,4 @@ Atmosphere::Atmosphere(int num_levels, const ColumnView temp,
                    "Height view must have extent >= " << num_levels);
 }
 
-}  // namespace haero
+} // namespace haero

--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -8,7 +8,7 @@ namespace haero {
 /// @class Atmosphere
 /// This type stores atmospheric state variables inherited from a host model.
 class Atmosphere final {
- public:
+public:
   /// Default constructor.
   /// CAUTION: only useful for creating placeholders in views!
   Atmosphere() = default;
@@ -45,7 +45,7 @@ class Atmosphere final {
   // Copy construction and assignment are supported for moving data between
   // host and device, and for populating multi-column views.
   Atmosphere(const Atmosphere &) = default;
-  Atmosphere& operator=(const Atmosphere&) = default;
+  Atmosphere &operator=(const Atmosphere &) = default;
 
   /// Destructor.
   KOKKOS_FUNCTION
@@ -74,24 +74,26 @@ class Atmosphere final {
   /// Returns true iff all atmospheric quantities are nonnegative, using the
   /// given thread team to parallelize the check.
   KOKKOS_INLINE_FUNCTION
-  bool quantities_nonnegative(const ThreadTeam& team) const {
+  bool quantities_nonnegative(const ThreadTeam &team) const {
     const int nk = num_levels();
     int violations = 0;
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, nk),
-      KOKKOS_CLASS_LAMBDA(int k, int& violation) {
-        if ((temperature(k) < 0) || (pressure(k) < 0) ||
-            (vapor_mixing_ratio(k) < 0)) {
-          violation = 1;
-        }
-      }, violations);
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(team, nk),
+        KOKKOS_CLASS_LAMBDA(int k, int &violation) {
+          if ((temperature(k) < 0) || (pressure(k) < 0) ||
+              (vapor_mixing_ratio(k) < 0)) {
+            violation = 1;
+          }
+        },
+        violations);
     return (violations == 0);
   }
 
- private:
+private:
   // Number of vertical levels.
   int num_levels_;
 };
 
-}  // namespace haero
+} // namespace haero
 
 #endif

--- a/haero/floating_point.hpp
+++ b/haero/floating_point.hpp
@@ -3,8 +3,8 @@
 
 #include <haero/haero.hpp>
 
-#include <ekat/ekat_assert.hpp>
 #include <Kokkos_Core.hpp>
+#include <ekat/ekat_assert.hpp>
 
 namespace haero {
 
@@ -14,8 +14,7 @@ using std::abs;
   struct for help with common floating point operations
 
 */
-template <typename T = Real>
-struct FloatingPoint {
+template <typename T = Real> struct FloatingPoint {
   static_assert(std::is_floating_point<T>::value,
                 "floating point type required.");
 
@@ -80,5 +79,5 @@ struct FloatingPoint {
   }
 };
 
-}  // namespace haero
+} // namespace haero
 #endif

--- a/haero/gas_species.hpp
+++ b/haero/gas_species.hpp
@@ -18,5 +18,5 @@ struct GasSpecies final {
   Real molecular_weight;
 };
 
-}  // namespace haero
+} // namespace haero
 #endif

--- a/haero/haero.hpp
+++ b/haero/haero.hpp
@@ -22,7 +22,7 @@ typedef Kokkos::HostSpace MemorySpace;
 
 /// Device and host types
 using DeviceType = ekat::KokkosTypes<ekat::DefaultDevice>;
-using HostType   = ekat::KokkosTypes<ekat::HostDevice>;
+using HostType = ekat::KokkosTypes<ekat::HostDevice>;
 
 /// Execution space (based on DeviceType)
 using ExecutionSpace = typename DeviceType::ExeSpace;
@@ -54,15 +54,15 @@ using DiagnosticsView = typename DeviceType::view_3d<Real>;
 using ColumnView = typename DeviceType::view_1d<Real>;
 
 // Returns haero's version string.
-const char* version();
+const char *version();
 
 // Returns haero's git revision hash, or "unknown" if not found.
-const char* revision();
+const char *revision();
 
 // Returns true iff this build has changes that weren't committed to the git
 // repo.
 bool has_uncommitted_changes();
 
-}  // end namespace haero
+} // end namespace haero
 
 #endif

--- a/haero/math.hpp
+++ b/haero/math.hpp
@@ -17,12 +17,12 @@ namespace haero {
 using ::cbrt;
 using ::erf;
 using ::exp;
-using ::pow;
 using ::expm1;
 using ::isinf;
 using ::isnan;
 using ::log;
 using ::log10;
+using ::pow;
 using ::sqrt;
 using ::tanh;
 using ::tgamma;
@@ -30,41 +30,33 @@ using ::tgamma;
 using std::cbrt;
 using std::erf;
 using std::exp;
-using std::pow;
 using std::expm1;
 using std::isinf;
 using std::isnan;
 using std::log;
 using std::log10;
+using std::pow;
 using std::sqrt;
 using std::tanh;
 using std::tgamma;
 #endif
 
 //// bring in kokkos math functions
-//using namespace Kokkos::Experimental;
+// using namespace Kokkos::Experimental;
 
 /// Returns the minimum of a and b.
 KOKKOS_INLINE_FUNCTION
-Real min(Real a, Real b) {
-  return (a < b) ? a : b;
-}
+Real min(Real a, Real b) { return (a < b) ? a : b; }
 
 // Returns the maximum of a and b.
 KOKKOS_INLINE_FUNCTION
-Real max(Real a, Real b) {
-  return (a > b) ? a : b;
-}
+Real max(Real a, Real b) { return (a > b) ? a : b; }
 
 KOKKOS_INLINE_FUNCTION
-Real square(Real x) {
-  return x * x;
-}
+Real square(Real x) { return x * x; }
 
 KOKKOS_INLINE_FUNCTION
-Real cube(Real x) {
-  return x * x * x;
-}
+Real cube(Real x) { return x * x * x; }
 
-}  // namespace haero
+} // namespace haero
 #endif

--- a/haero/root_finders.hpp
+++ b/haero/root_finders.hpp
@@ -12,8 +12,7 @@ namespace math {
   converge. It may converge to an incorrect root if a poor initial guess is
   chosen. It requires both function values and derivative values.
 */
-template <typename ScalarFunction>
-struct NewtonSolver {
+template <typename ScalarFunction> struct NewtonSolver {
   using value_type = typename ScalarFunction::value_type;
 
   /// maximum number of iterations allowed per solve
@@ -27,7 +26,7 @@ struct NewtonSolver {
   /// absolute difference between two consecutive iterations
   value_type iter_diff;
   /// Scalar function whose root we need
-  const ScalarFunction& f;
+  const ScalarFunction &f;
   /// true if a failure condition is met
   bool fail;
 
@@ -40,19 +39,15 @@ struct NewtonSolver {
     @param [in] fn ScalarFunction instance whose root needs to be found
   */
   KOKKOS_INLINE_FUNCTION
-  NewtonSolver(const value_type x0, const value_type a0, const value_type b0, const Real& tol,
-                     const ScalarFunction& fn)
-      : xroot(x0),
-        conv_tol(tol),
-        counter(0),
-        iter_diff(std::numeric_limits<Real>::max()),
-        f(fn),
-        fail(false) {}
+  NewtonSolver(const value_type x0, const value_type a0, const value_type b0,
+               const Real &tol, const ScalarFunction &fn)
+      : xroot(x0), conv_tol(tol), counter(0),
+        iter_diff(std::numeric_limits<Real>::max()), f(fn), fail(false) {}
 
   /// Solves for the root.  Prints a warning message if the convergence
   /// tolerance is not met before the maximum number of iterations is achieved.
   KOKKOS_INLINE_FUNCTION
-  value_type solve() {return solve_impl<value_type>();}
+  value_type solve() { return solve_impl<value_type>(); }
 
   template <typename VT>
   KOKKOS_INLINE_FUNCTION
@@ -65,7 +60,8 @@ struct NewtonSolver {
       const value_type xnp1 = xroot - f(xroot) / f.derivative(xroot);
       iter_diff = abs(xnp1 - xroot);
       keep_going = !(FloatingPoint<value_type>::zero(iter_diff, conv_tol));
-      EKAT_KERNEL_ASSERT_MSG(counter <= max_iter, "NewtonSolver: max iterations");
+      EKAT_KERNEL_ASSERT_MSG(counter <= max_iter,
+                             "NewtonSolver: max iterations");
       if (counter > max_iter) {
         keep_going = false;
         fail = true;
@@ -94,8 +90,7 @@ robustness of the bisection method. In addition to the requirement that the
 initial interval contains a root, this solver requires that function value at
 the initial interval endpoints have opposite sign.
 */
-template <typename ScalarFunction>
-struct BracketedNewtonSolver {
+template <typename ScalarFunction> struct BracketedNewtonSolver {
   using value_type = typename ScalarFunction::value_type;
   static constexpr int max_iter = 200;
   value_type xroot;
@@ -105,7 +100,7 @@ struct BracketedNewtonSolver {
   value_type fa;
   value_type fx;
   value_type fb;
-  const ScalarFunction& f;
+  const ScalarFunction &f;
   int counter;
   value_type iter_diff;
   /// true if a failure condition is met
@@ -120,19 +115,12 @@ struct BracketedNewtonSolver {
     @param [in] fn ScalarFunction instance whose root needs to be found
   */
   KOKKOS_INLINE_FUNCTION
-  BracketedNewtonSolver(const value_type x0, const value_type a0, const value_type b0,
-                        const Real tol, const ScalarFunction& fn)
-      : xroot(x0),
-        a(a0),
-        b(b0),
-        conv_tol(tol),
-        fa(fn(value_type(a0))),
-        fx(fn(x0)),
-        fb(fn(value_type(b0))),
-        f(fn),
-        counter(0),
-        iter_diff(std::numeric_limits<Real>::max()),
-        fail(false) {
+  BracketedNewtonSolver(const value_type x0, const value_type a0,
+                        const value_type b0, const Real tol,
+                        const ScalarFunction &fn)
+      : xroot(x0), a(a0), b(b0), conv_tol(tol), fa(fn(value_type(a0))),
+        fx(fn(x0)), fb(fn(value_type(b0))), f(fn), counter(0),
+        iter_diff(std::numeric_limits<Real>::max()), fail(false) {
     EKAT_KERNEL_ASSERT(b - a > 0.0);
     EKAT_KERNEL_ASSERT(fa * fb < 0.0);
   }
@@ -170,7 +158,8 @@ struct BracketedNewtonSolver {
       iter_diff = abs(x - xroot);
       keep_going = !FloatingPoint<value_type>::zero(iter_diff, conv_tol);
       // prevent infinite loops
-      EKAT_KERNEL_ASSERT_MSG(counter <= max_iter, "BracketedNewtonSolver: max iterations");
+      EKAT_KERNEL_ASSERT_MSG(counter <= max_iter,
+                             "BracketedNewtonSolver: max iterations");
       if (counter > max_iter) {
         keep_going = false;
         fail = true;
@@ -197,8 +186,7 @@ struct BracketedNewtonSolver {
   For an application example, see KohlerPolynomial.
 
 */
-template <typename ScalarFunction>
-struct BisectionSolver {
+template <typename ScalarFunction> struct BisectionSolver {
   using value_type = typename ScalarFunction::value_type;
 
   /// maximum number of iterations allowed
@@ -220,7 +208,7 @@ struct BisectionSolver {
   /// width of the current search interval
   value_type iter_diff;
   /// scalar function whose root we need
-  const ScalarFunction& f;
+  const ScalarFunction &f;
   /// true if a failure condition is met
   bool fail;
 
@@ -233,17 +221,10 @@ struct BisectionSolver {
     @param [in] fn ScalarFunction instance whose root needs to be found
   */
   KOKKOS_INLINE_FUNCTION
-  BisectionSolver(const value_type x0, const value_type a0, const value_type b0, const Real tol,
-                  const ScalarFunction& fn)
-      : xroot(0.5 * (a0 + b0)),
-        a(a0),
-        b(b0),
-        conv_tol(tol),
-        fa(fn(a0)),
-        xnp1(0.5 * (a0 + b0)),
-        counter(0),
-        iter_diff(b0 - a0),
-        f(fn),
+  BisectionSolver(const value_type x0, const value_type a0, const value_type b0,
+                  const Real tol, const ScalarFunction &fn)
+      : xroot(0.5 * (a0 + b0)), a(a0), b(b0), conv_tol(tol), fa(fn(a0)),
+        xnp1(0.5 * (a0 + b0)), counter(0), iter_diff(b0 - a0), f(fn),
         fail(false) {}
 
   /// Solves for the root.  Prints a warning message if the convergence
@@ -270,7 +251,8 @@ struct BisectionSolver {
       iter_diff = b - a;
       xroot = xnp1;
       keep_going = !(FloatingPoint<value_type>::zero(iter_diff, conv_tol));
-      EKAT_KERNEL_ASSERT_MSG(counter <= max_iter, "BisectionSolver: max iterations");
+      EKAT_KERNEL_ASSERT_MSG(counter <= max_iter,
+                             "BisectionSolver: max iterations");
       if (counter > max_iter) {
         keep_going = false;
         fail = true;
@@ -283,7 +265,6 @@ struct BisectionSolver {
     return xroot;
   }
 };
-
 
 } // namespace math
 } // namespace haero

--- a/haero/tests/math_tests.cpp
+++ b/haero/tests/math_tests.cpp
@@ -1,9 +1,8 @@
 #include <cmath>
 #include <iostream>
 
-#include "math_tests.hpp"
 #include "catch2/catch.hpp"
-
+#include "math_tests.hpp"
 
 using namespace haero;
 
@@ -18,8 +17,8 @@ TEST_CASE("haero_math_powers", "") {
 }
 
 TEST_CASE("haero_math_rootfinding", "") {
-  const Real cubic_root = sqrt(3.0/5.0);
-  const Real quartic_root = sqrt((15.0 + 2*sqrt(30.0))/35.0);
+  const Real cubic_root = sqrt(3.0 / 5.0);
+  const Real quartic_root = sqrt((15.0 + 2 * sqrt(30.0)) / 35.0);
 
   using cubic_leg_poly = math::LegendreCubic<Real>;
   using quartic_leg_poly = math::LegendreQuartic<Real>;
@@ -27,7 +26,7 @@ TEST_CASE("haero_math_rootfinding", "") {
   cubic_leg_poly p3;
   quartic_leg_poly p4;
 
-  const Real conv_tol = 100*FloatingPoint<Real>::zero_tol;
+  const Real conv_tol = 100 * FloatingPoint<Real>::zero_tol;
   std::cout << "convergence tolerance = " << conv_tol << "\n";
 
   const Real a0 = 0.5;
@@ -36,7 +35,8 @@ TEST_CASE("haero_math_rootfinding", "") {
 
   SECTION("Newton solve") {
 
-    auto cubic_solver = math::NewtonSolver<cubic_leg_poly>(x0, a0, b0, conv_tol, p3);
+    auto cubic_solver =
+        math::NewtonSolver<cubic_leg_poly>(x0, a0, b0, conv_tol, p3);
     const Real cubic_sol = cubic_solver.solve();
 
     std::cout << "newton cubic_sol rel. error = "
@@ -45,7 +45,8 @@ TEST_CASE("haero_math_rootfinding", "") {
 
     REQUIRE(cubic_sol == Approx(cubic_root));
 
-    auto quartic_solver = math::NewtonSolver<quartic_leg_poly>(x0, a0, b0, conv_tol, p4);
+    auto quartic_solver =
+        math::NewtonSolver<quartic_leg_poly>(x0, a0, b0, conv_tol, p4);
     const Real quartic_sol = quartic_solver.solve();
 
     std::cout << "newton quartic_sol rel. error = "
@@ -56,7 +57,8 @@ TEST_CASE("haero_math_rootfinding", "") {
   }
 
   SECTION("bisection_solve") {
-    auto cubic_solver = math::BisectionSolver<cubic_leg_poly>(x0, a0, b0, conv_tol, p3);
+    auto cubic_solver =
+        math::BisectionSolver<cubic_leg_poly>(x0, a0, b0, conv_tol, p3);
     const Real cubic_sol = cubic_solver.solve();
     std::cout << "bisection cubic_sol rel. error = "
               << std::abs(cubic_sol - cubic_root) / cubic_root
@@ -64,7 +66,8 @@ TEST_CASE("haero_math_rootfinding", "") {
 
     REQUIRE(cubic_sol == Approx(cubic_root));
 
-    auto quartic_solver = math::BisectionSolver<quartic_leg_poly>(x0, a0, b0, conv_tol, p4);
+    auto quartic_solver =
+        math::BisectionSolver<quartic_leg_poly>(x0, a0, b0, conv_tol, p4);
     const Real quartic_sol = quartic_solver.solve();
     std::cout << "bisection quartic_sol rel. error = "
               << std::abs(quartic_sol - quartic_root) / quartic_root
@@ -73,7 +76,8 @@ TEST_CASE("haero_math_rootfinding", "") {
   }
 
   SECTION("bracketed_newton_solve") {
-    auto cubic_solver = math::BracketedNewtonSolver<cubic_leg_poly>(x0, a0, b0, conv_tol, p3);
+    auto cubic_solver =
+        math::BracketedNewtonSolver<cubic_leg_poly>(x0, a0, b0, conv_tol, p3);
     const Real cubic_sol = cubic_solver.solve();
     std::cout << "bracketed newton cubic_sol rel. error = "
               << std::abs(cubic_sol - cubic_root) / cubic_root
@@ -81,7 +85,8 @@ TEST_CASE("haero_math_rootfinding", "") {
 
     REQUIRE(cubic_sol == Approx(cubic_root));
 
-    auto quartic_solver = math::BracketedNewtonSolver<quartic_leg_poly>(x0, a0, b0, conv_tol, p4);
+    auto quartic_solver =
+        math::BracketedNewtonSolver<quartic_leg_poly>(x0, a0, b0, conv_tol, p4);
     const Real quartic_sol = quartic_solver.solve();
     std::cout << "bracketed newton quartic_sol rel. error = "
               << std::abs(quartic_sol - quartic_root) / quartic_root
@@ -95,20 +100,19 @@ TEST_CASE("no_root", "") {
 
   quadratic_poly qpoly;
 
-  const Real conv_tol = 100*FloatingPoint<Real>::zero_tol;
+  const Real conv_tol = 100 * FloatingPoint<Real>::zero_tol;
   std::cout << "convergence tolerance = " << conv_tol << "\n";
 
   const Real x0 = 0;
   const Real a0 = -1;
   const Real b0 = 1;
 
-  auto quadratic_solver = math::NewtonSolver<quadratic_poly>(x0, a0, b0, conv_tol, qpoly);
+  auto quadratic_solver =
+      math::NewtonSolver<quadratic_poly>(x0, a0, b0, conv_tol, qpoly);
   const Real qsol = quadratic_solver.solve();
   std::cout << "newton quadratic_sol = " << qsol
             << " n_iter = " << quadratic_solver.counter << "\n";
 
-  REQUIRE( quadratic_solver.fail );
-  REQUIRE( isnan(qsol) );
+  REQUIRE(quadratic_solver.fail);
+  REQUIRE(isnan(qsol));
 }
-
-

--- a/haero/tests/math_tests.hpp
+++ b/haero/tests/math_tests.hpp
@@ -1,9 +1,9 @@
 #ifndef HAERO_MATH_TESTS_HPP
 #define HAERO_MATH_TESTS_HPP
 
+#include "haero/floating_point.hpp"
 #include "haero/haero.hpp"
 #include "haero/math.hpp"
-#include "haero/floating_point.hpp"
 
 #include "haero/math.hpp"
 #include "haero/root_finders.hpp"
@@ -24,8 +24,7 @@ namespace math {
 
   For an application example, see KohlerPolynomial.
 */
-template <typename T>
-struct LegendreCubic {
+template <typename T> struct LegendreCubic {
   static_assert(std::is_floating_point<
                     typename ekat::ScalarTraits<T>::scalar_type>::value,
                 "floating point type");
@@ -37,12 +36,12 @@ struct LegendreCubic {
   LegendreCubic() {}
 
   KOKKOS_INLINE_FUNCTION
-  T operator()(const T& xin) const { return 0.5 * (-3 * xin + 5 * cube(xin)); }
+  T operator()(const T &xin) const { return 0.5 * (-3 * xin + 5 * cube(xin)); }
 
   /// @brief Derivative of the cubic Legendre polynomial, @f$ \frac{d
   /// P_3}{dx}(x) @f$
   KOKKOS_INLINE_FUNCTION
-  T derivative(const T& xin) const { return 0.5 * (-3 + 15 * square(xin)); }
+  T derivative(const T &xin) const { return 0.5 * (-3 + 15 * square(xin)); }
 };
 
 /** @brief Quartic Legendre polynomial, @f$ P_4(x) @f$
@@ -57,8 +56,7 @@ struct LegendreCubic {
 
   For an application example, see KohlerPolynomial.
 */
-template <typename T>
-struct LegendreQuartic {
+template <typename T> struct LegendreQuartic {
   static_assert(std::is_floating_point<
                     typename ekat::ScalarTraits<T>::scalar_type>::value,
                 "floating point type.");
@@ -92,10 +90,10 @@ struct LegendreQuartic {
   If it is to be used by the Newton solver, it must also implement the
   derivative(const T x) method, which returns f'(x).
 */
-template <typename T>
-struct MonicParabola {
-  static_assert(std::is_floating_point<typename ekat::ScalarTraits<T>::scalar_type>::value,
-    "floating point type.");
+template <typename T> struct MonicParabola {
+  static_assert(std::is_floating_point<
+                    typename ekat::ScalarTraits<T>::scalar_type>::value,
+                "floating point type.");
   using value_type = T;
   using scalar_type = typename ekat::ScalarTraits<T>::scalar_type;
 
@@ -106,7 +104,7 @@ struct MonicParabola {
   MonicParabola() : a(0), b(3) {}
 
   KOKKOS_INLINE_FUNCTION
-  T operator() (const T xin) const {
+  T operator()(const T xin) const {
     const T aa(a);
     const T bb(b);
     return square(xin) + aa * xin + bb;
@@ -115,7 +113,7 @@ struct MonicParabola {
   KOKKOS_INLINE_FUNCTION
   T derivative(const T xin) const {
     const T aa(a);
-    return 2*xin + aa;
+    return 2 * xin + aa;
   }
 };
 

--- a/haero/utils.cpp
+++ b/haero/utils.cpp
@@ -17,14 +17,14 @@ std::string indent_string(const int tab_lev) {
 
 std::string line_delim() { return "------------------------------\n"; }
 
-std::string& tolower(std::string& s) {
-  for (auto& c : s) {
+std::string &tolower(std::string &s) {
+  for (auto &c : s) {
     c = std::tolower(c);
   }
   return s;
 }
 
-bool is_boolean(const std::string& s) {
+bool is_boolean(const std::string &s) {
   return ((strcasecmp("true", s.c_str()) == 0) ||
           (strcasecmp("false", s.c_str()) == 0) ||
           (strcasecmp("yes", s.c_str()) == 0) ||
@@ -33,7 +33,7 @@ bool is_boolean(const std::string& s) {
           (strcasecmp("off", s.c_str()) == 0));
 }
 
-bool as_boolean(const std::string& s) {
+bool as_boolean(const std::string &s) {
   EKAT_REQUIRE_MSG(is_boolean(s), "'" << s << "' is not a boolean!\n"
                                       << "Must be one of (case-insensitive):\n"
                                       << "* \"true\", \"false\"\n"
@@ -44,7 +44,7 @@ bool as_boolean(const std::string& s) {
           (strcasecmp("on", s.c_str()) == 0));
 }
 
-std::string get_filename_ext(const std::string& fname) {
+std::string get_filename_ext(const std::string &fname) {
   const auto dotpos = fname.rfind('.');
   std::string result = "";
   if (dotpos != std::string::npos) {
@@ -53,7 +53,7 @@ std::string get_filename_ext(const std::string& fname) {
   return result;
 }
 
-bool vector_is_monotone(const std::vector<Real>& vals) {
+bool vector_is_monotone(const std::vector<Real> &vals) {
   bool result = true;
   if (vals.size() > 1) {
     // check increasing or decreasing based on first 2 values
@@ -77,4 +77,4 @@ bool vector_is_monotone(const std::vector<Real>& vals) {
   return result;
 }
 
-}  // namespace haero
+} // namespace haero

--- a/haero/utils.hpp
+++ b/haero/utils.hpp
@@ -18,21 +18,21 @@ namespace haero {
 std::string indent_string(const int tab_lev);
 
 /// convert a string to lower case
-std::string& tolower(std::string& s);
+std::string &tolower(std::string &s);
 
 /// Returns true if the string s can be interpreted as a boolean variable, false
 /// if not. Valid (case-insensitive) boolean values are:
 /// * true/false
 /// * yes/no
 /// * on/off
-bool is_boolean(const std::string& s);
+bool is_boolean(const std::string &s);
 
 /// Returns the boolean value interpreted from the string s. If is_boolean(s)
 /// returns false, this function throws an exception.
-bool as_boolean(const std::string& s);
+bool as_boolean(const std::string &s);
 
 /// Get the filename extension from a string containing a filename
-std::string get_filename_ext(const std::string& fname);
+std::string get_filename_ext(const std::string &fname);
 
 /// Write a horizontal line to a string
 std::string line_delim();
@@ -45,7 +45,7 @@ std::string line_delim();
 
   @param [in] vals
 */
-bool vector_is_monotone(const std::vector<Real>& vals);
+bool vector_is_monotone(const std::vector<Real> &vals);
 
 /** @brief A simple progress bar to show program % completion with the console.
  */
@@ -55,15 +55,15 @@ class ProgressBar {
   Real freq_;
   int it_;
   Real next_;
-  std::ostream& os_;
+  std::ostream &os_;
 
- public:
-  ProgressBar(const std::string& name, const int niterations,
-              const Real write_freq = 10.0, std::ostream& os = std::cout);
+public:
+  ProgressBar(const std::string &name, const int niterations,
+              const Real write_freq = 10.0, std::ostream &os = std::cout);
 
   void update();
 };
 
 /// @} defgroup utilities
-}  // namespace haero
+} // namespace haero
 #endif

--- a/machines/compy.sh
+++ b/machines/compy.sh
@@ -1,10 +1,10 @@
-# This file loads all necessary modules for building MAM on PNNL's Compy Machine
+# This file loads all necessary modules for building Haero on Compy (PNNL).
 
 source /etc/profile.d/modules.sh
 
 # Load relevant modules:
 #(Intel 20.0)
-module purge && module load gcc/10.2.0 openmpi/4.0.1 cmake/3.19.6  
+module purge && module load gcc/10.2.0 openmpi/4.0.1 cmake/3.19.6
 
 # Set relevant compilers.
 export FC=gfortran

--- a/machines/constance.sh
+++ b/machines/constance.sh
@@ -1,4 +1,4 @@
-# This file loads all necessary modules for building MAM on Constance (PNNL)
+# This file loads all necessary modules for building Haero on Constance (PNNL)
 
 source /etc/profile.d/modules.sh
 module purge

--- a/machines/cori.sh
+++ b/machines/cori.sh
@@ -1,4 +1,4 @@
-# This file loads all necessary modules for building MAM on NERSC Cori (KNL nodes).
+# This file loads all necessary modules for building Haero on NERSC Cori (KNL nodes).
 
 # Load relevant modules
 module purge

--- a/machines/deception.sh
+++ b/machines/deception.sh
@@ -1,0 +1,7 @@
+# This file loads all necessary modules for building Haero on Deception (PNNL)
+
+module load gcc/7.3.0
+module load cmake/3.21.4
+module load openmpi/4.1.0mlx5.0
+module load python/3.7.0
+module load cuda/11.4

--- a/machines/marianas.pnl.gov.sh
+++ b/machines/marianas.pnl.gov.sh
@@ -1,4 +1,4 @@
-# This file loads all necessary modules for building MAM on PNNL's Marianas system
+# This file loads all necessary modules for building Haero on Marianas (PNNL).
 
 module purge
 

--- a/machines/s1024454.sh
+++ b/machines/s1024454.sh
@@ -1,4 +1,4 @@
-# This file sets up the environment variables for building MAM on s1024454.srn.sandia.gov
+# This file sets up the environment variables for building Haero on s1024454.srn.sandia.gov
 #
 # It's a rhel7 linux box with an intel skylake gold (24 cores with 2 threads per core over 2 sockets)
 # with an nvidia maxwell gpu.

--- a/machines/s1061858.sh
+++ b/machines/s1061858.sh
@@ -1,4 +1,4 @@
-# This file sets up the environment variables for building MAM on s1068158.srn.sandia.gov
+# This file sets up the environment variables for building Haero on s1068158.srn.sandia.gov
 #
 # It's a 2020 macbook pro using Apple's clang-11.0, gfortran-11.2, and open-mpi-4.0.5
 #

--- a/setup
+++ b/setup
@@ -304,6 +304,6 @@ echo "Your build directory '$1' is ready."
 echo "To configure your build:"
 echo "  1. cd $1"
 echo "  2. Edit config.sh"
-echo "  3. ./config.sh"
+echo "  3. source config.sh"
 echo "  4. Build using 'make -j'."
 

--- a/tools/update_version_info.sh
+++ b/tools/update_version_info.sh
@@ -12,9 +12,12 @@ patch_version=`grep '(HAERO_PATCH_VERSION' $1/CMakeLists.txt | sed -e 's/set (//
 which_git_wc=`which git | wc -l`
 
 if [ $which_git_wc -gt 0 ]; then
+  cwd=`pwd`
+  cd $1
   # Ask git for the revision and for diff information.
   git_revision=`git log -1 --format=format:%h`
   git_diffs=`git diff | wc -l`
+  cd $cwd
 else
   git_revision="unknown"
   git_diffs=0


### PR DESCRIPTION
This is just a clean-up PR that switches Haero to LLVM's C++ formatting rules, since that's what we're using for mam4xx, and 1 style is simpler than 2. This PR also restarts the formatting check for new PRs.

@jaelynlitz , I also added your machine file for Deception here. If the hostname matches `deception`, Haero should automatically source this. Let me know if you think it works if you get a chance.

Fixes #421