### PR TITLE
PNNL Hostname Search

### DIFF
--- a/setup
+++ b/setup
@@ -181,10 +181,10 @@ pushd "\$SOURCE_DIR"/machines >& /dev/null
 for MACHINE_FILE in \$(ls)
 do
   MACHINE=\${MACHINE_FILE/\.sh/}
-  echo `hostname` | grep -q "\$MACHINE" 
-  host_match=$\?
+  echo \`hostname\` | grep -q "\$MACHINE" 
+  host_match=\$?
   echo \$SYSTEM_NAME | grep -q "\$MACHINE"
-  sys_match=$\?
+  sys_match=\$?
   if  [ \$host_match -eq 0 ] || [ \$sys_match -eq 0 ]; then
     echo "Found machine file \$MACHINE_FILE. Setting up environment for \$MACHINE..."
     . ./\$MACHINE.sh

--- a/setup
+++ b/setup
@@ -181,7 +181,11 @@ pushd "\$SOURCE_DIR"/machines >& /dev/null
 for MACHINE_FILE in \$(ls)
 do
   MACHINE=\${MACHINE_FILE/\.sh/}
-  if echo `hostname` | grep -q "\$MACHINE"; then
+  echo `hostname` | grep -q "\$MACHINE" 
+  host_match=$\?
+  echo \$SYSTEM_NAME | grep -q "\$MACHINE"
+  sys_match=$\?
+  if  [ \$host_match -eq 0 ] || [ \$sys_match -eq 0 ]; then
     echo "Found machine file \$MACHINE_FILE. Setting up environment for \$MACHINE..."
     . ./\$MACHINE.sh
   fi

--- a/setup
+++ b/setup
@@ -187,7 +187,7 @@ do
   sys_match=\$?
   if  [ \$host_match -eq 0 ] || [ \$sys_match -eq 0 ]; then
     echo "Found machine file \$MACHINE_FILE. Setting up environment for \$MACHINE..."
-    . ./\$MACHINE.sh
+    source ./\$MACHINE.sh
   fi
 done
 popd >& /dev/null


### PR DESCRIPTION
Small fix to search for the hostname to work even when on a compute node (not just the login node)

On PNNL's clusters, the variable SYSTEM_NAME is set to be the cluster name without the .pnl.gov (i.e. so on dl09, SYSTEM_NAME=deception)

LMK if there's a smoother way to do this check in bash