### PR TITLE
Turn off warnings for using deprecated functions in Kokkos.

### DIFF
--- a/setup
+++ b/setup
@@ -275,6 +275,11 @@ if [ ! "\$EXTRA_LDFLAGS" = "" ]; then
   OPTIONS="\$OPTIONS -DHAERO_EXTRA_LDFLAGS=\$EXTRA_LDFLAGS"
 fi
 
+# Add flag to turn off warnings for use of deprecated
+# functions in Kokkos.
+# See eagles-project/mam4xx Issue #99 for more details.
+OPTIONS="\$OPTIONS -DKokkos_ENABLE_DEPRECATION_WARNINGS:BOOL=OFF"
+
 # Clear the build cache.
 rm -f CMakeCache.txt
 


### PR DESCRIPTION
See eagles-project/mam4xx Issue #99 for more details. The Kokkos::OpenMP::partition_master() is deprecated but mam4xx is still somehow using it. Since warnings are errors, this causes compile problems. Turning off the warning should fix it.