### PR TITLE
adding const column views

### DIFF
--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -40,38 +40,38 @@ public:
   // views storing atmospheric state data for a single vertical column
 
   /// temperature [K]
-  ColumnView temperature;
+  ConstColumnView temperature;
 
   /// pressure [Pa]
-  ColumnView pressure;
+  ConstColumnView pressure;
 
   /// water vapor mass mixing ratio [kg vapor/kg dry air]
-  ColumnView vapor_mixing_ratio;
+  ConstColumnView vapor_mixing_ratio;
 
   /// liquid water mass mixing ratio [kg vapor/kg dry air]
-  ColumnView liquid_mixing_ratio;
+  ConstColumnView liquid_mixing_ratio;
 
   /// grid box averaged cloud liquid number mixing ratio [#/kg dry air]
-  ColumnView cloud_liquid_number_mixing_ratio;
+  ConstColumnView cloud_liquid_number_mixing_ratio;
 
   /// ice water mass mixing ratio [kg vapor/kg dry air]
-  ColumnView ice_mixing_ratio;
+  ConstColumnView ice_mixing_ratio;
 
   // grid box averaged cloud ice number mixing ratio [#/kg dry air]
-  ColumnView cloud_ice_number_mixing_ratio;
+  ConstColumnView cloud_ice_number_mixing_ratio;
 
   /// height at the midpoint of each vertical level [m]
-  ColumnView height;
+  ConstColumnView height;
 
   /// hydroѕtatic "pressure thickness" defined as the difference in hydrostatic
   /// pressure levels between the interfaces bounding a vertical level [Pa]
-  ColumnView hydrostatic_dp;
+  ConstColumnView hydrostatic_dp;
 
   /// cloud fraction [-]
-  ColumnView cloud_fraction;
+  ConstColumnView cloud_fraction;
 
   /// vertical updraft velocity used for ice nucleation [m/s]
-  ColumnView updraft_vel_ice_nucleation;
+  ConstColumnView updraft_vel_ice_nucleation;
 
   // column-specific planetary boundary layer height [m]
   Real planetary_boundary_layer_height;

--- a/haero/haero.hpp
+++ b/haero/haero.hpp
@@ -58,6 +58,7 @@ using DiagnosticsView = typename DeviceType::view_3d<Real>;
 /// own their storage. This allows a host model to manage column data for
 /// any Haero aerosol packages.
 using ColumnView = ekat::Unmanaged<typename DeviceType::view_1d<Real>>;
+using ConstColumnView = ekat::Unmanaged<typename DeviceType::view_1d<const Real>>;
 
 // Returns haero's version string.
 const char *version();


### PR DESCRIPTION
EamXX enforces `const`-correctness in its views.  This means we have to declare column views correctly, i.e., `Kokkos::View<const Real*>` for views that we do not change, and `Kokkos::View<Real*>` for views that we do change.

This PR adds a `ConstColumnView` typedef to make this a little easier; when you find a `ColumnView` that should be const, just change its declaration to `ConstColumnView`.

First up: `haero::Atmosphere`.   This PR changes all column views in `haero::Atmosphere` to `ConstColumnView` types.