### PR TITLE
Adding a ConstColumnView type for Atmosphere views

### DIFF
--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -21,40 +21,29 @@ public:
   /// Constructs an Atmosphere object holding the state for a single atmospheric
   /// column with the given planetary boundary layer height.
   /// All views must be set manually elsewhere or provided by a host model.
-  Atmosphere(const ConstColumnView T, const ConstColumnView p, const ConstColumnView qv,
-    const ConstColumnView qc, const ConstColumnView nqc, const ConstColumnView qi,
-    const ConstColumnView nqi, const ConstColumnView z, const ConstColumnView hdp,
-    const ConstColumnView cf, const ConstColumnView w, const Real pblh) :
-      num_levels_(T.extent(0)),
-      temperature(T),
-      pressure(p),
-      vapor_mixing_ratio(qv),
-      liquid_mixing_ratio(qc),
-      cloud_liquid_number_mixing_ratio(nqc),
-      ice_mixing_ratio(qi),
-      cloud_ice_number_mixing_ratio(nqi),
-      height(z),
-      hydrostatic_dp(hdp),
-      cloud_fraction(cf),
-      updraft_vel_ice_nucleation(w),
-      planetary_boundary_layer_height(pblh) {
+  Atmosphere(const ConstColumnView T, const ConstColumnView p,
+             const ConstColumnView qv, const ConstColumnView qc,
+             const ConstColumnView nqc, const ConstColumnView qi,
+             const ConstColumnView nqi, const ConstColumnView z,
+             const ConstColumnView hdp, const ConstColumnView cf,
+             const ConstColumnView w, const Real pblh)
+      : num_levels_(T.extent(0)), temperature(T), pressure(p),
+        vapor_mixing_ratio(qv), liquid_mixing_ratio(qc),
+        cloud_liquid_number_mixing_ratio(nqc), ice_mixing_ratio(qi),
+        cloud_ice_number_mixing_ratio(nqi), height(z), hydrostatic_dp(hdp),
+        cloud_fraction(cf), updraft_vel_ice_nucleation(w),
+        planetary_boundary_layer_height(pblh) {
 
-        EKAT_ASSERT(T.extent(0) > 0);
+    EKAT_ASSERT(T.extent(0) > 0);
 
-        EKAT_ASSERT(
-          T.extent(0) == p.extent(0) &&
-          T.extent(0) == qv.extent(0) &&
-          T.extent(0) == qc.extent(0) &&
-          T.extent(0) == nqc.extent(0) &&
-          T.extent(0) == qi.extent(0) &&
-          T.extent(0) == nqi.extent(0) &&
-          T.extent(0) == z.extent(0) &&
-          T.extent(0) == hdp.extent(0) &&
-          T.extent(0) == cf.extent(0) &&
-          T.extent(0) == w.extent(0));
+    EKAT_ASSERT(T.extent(0) == p.extent(0) && T.extent(0) == qv.extent(0) &&
+                T.extent(0) == qc.extent(0) && T.extent(0) == nqc.extent(0) &&
+                T.extent(0) == qi.extent(0) && T.extent(0) == nqi.extent(0) &&
+                T.extent(0) == z.extent(0) && T.extent(0) == hdp.extent(0) &&
+                T.extent(0) == cf.extent(0) && T.extent(0) == w.extent(0));
 
-        EKAT_ASSERT(pblh >= 0.0);
-      }
+    EKAT_ASSERT(pblh >= 0.0);
+  }
 
   // use only for creating containers of Atmospheres!
   Atmosphere() = default;

--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -40,38 +40,38 @@ public:
   // views storing atmospheric state data for a single vertical column
 
   /// temperature [K]
-  ColumnView temperature;
+  ConstColumnView temperature;
 
   /// pressure [Pa]
-  ColumnView pressure;
+  ConstColumnView pressure;
 
   /// water vapor mass mixing ratio [kg vapor/kg dry air]
-  ColumnView vapor_mixing_ratio;
+  ConstColumnView vapor_mixing_ratio;
 
   /// liquid water mass mixing ratio [kg vapor/kg dry air]
-  ColumnView liquid_mixing_ratio;
+  ConstColumnView liquid_mixing_ratio;
 
   /// grid box averaged cloud liquid number mixing ratio [#/kg dry air]
-  ColumnView cloud_liquid_number_mixing_ratio;
+  ConstColumnView cloud_liquid_number_mixing_ratio;
 
   /// ice water mass mixing ratio [kg vapor/kg dry air]
-  ColumnView ice_mixing_ratio;
+  ConstColumnView ice_mixing_ratio;
 
   // grid box averaged cloud ice number mixing ratio [#/kg dry air]
-  ColumnView cloud_ice_number_mixing_ratio;
+  ConstColumnView cloud_ice_number_mixing_ratio;
 
   /// height at the midpoint of each vertical level [m]
-  ColumnView height;
+  ConstColumnView height;
 
   /// hydroѕtatic "pressure thickness" defined as the difference in hydrostatic
   /// pressure levels between the interfaces bounding a vertical level [Pa]
-  ColumnView hydrostatic_dp;
+  ConstColumnView hydrostatic_dp;
 
   /// cloud fraction [-]
-  ColumnView cloud_fraction;
+  ConstColumnView cloud_fraction;
 
   /// vertical updraft velocity used for ice nucleation [m/s]
-  ColumnView updraft_vel_ice_nucleation;
+  ConstColumnView updraft_vel_ice_nucleation;
 
   // column-specific planetary boundary layer height [m]
   Real planetary_boundary_layer_height;

--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -20,14 +20,43 @@ class Atmosphere final {
 public:
   /// Constructs an Atmosphere object holding the state for a single atmospheric
   /// column with the given planetary boundary layer height.
-  /// All views must be set manually.
-  Atmosphere(int num_levels, Real pblh)
-      : num_levels_(num_levels), planetary_boundary_layer_height(pblh) {
-    EKAT_ASSERT(num_levels > 0);
-    EKAT_ASSERT(pblh >= 0.0);
-  }
+  /// All views must be set manually elsewhere or provided by a host model.
+  Atmosphere(const ColumnView T, const ColumnView p, const ColumnView qv,
+    const ColumnView qc, const ColumnView nqc, const ColumnView qi,
+    const ColumnView nqi, const ColumnView z, const ColumnView hdp,
+    const ColumnView cf, const ColumnView w, const Real pblh) :
+      num_levels_(T.extent(0)),
+      temperature(T),
+      pressure(p),
+      vapor_mixing_ratio(qv),
+      liquid_mixing_ratio(qc),
+      cloud_liquid_number_mixing_ratio(nqc),
+      ice_mixing_ratio(qi),
+      cloud_ice_number_mixing_ratio(nqi),
+      height(z),
+      hydrostatic_dp(hdp),
+      cloud_fraction(cf),
+      updraft_vel_ice_nucleation(w),
+      planetary_boundary_layer_height(pblh) {
 
-  Atmosphere() = default; // use only for creating containers of Atmospheres!
+        EKAT_ASSERT(T.extent(0) > 0);
+
+        EKAT_ASSERT(
+          T.extent(0) == p.extent(0) &&
+          T.extent(0) == qv.extent(0) &&
+          T.extent(0) == qc.extent(0) &&
+          T.extent(0) == nqc.extent(0) &&
+          T.extent(0) == qi.extent(0) &&
+          T.extent(0) == nqi.extent(0) &&
+          T.extent(0) == z.extent(0) &&
+          T.extent(0) == hdp.extent(0) &&
+          T.extent(0) == cf.extent(0) &&
+          T.extent(0) == w.extent(0));
+
+        EKAT_ASSERT(pblh >= 0.0);
+      }
+
+  Atmosphere() = delete;
 
   // these are supported for initializing containers of Atmospheres
   Atmosphere(const Atmosphere &rhs) = default;

--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -56,7 +56,8 @@ public:
         EKAT_ASSERT(pblh >= 0.0);
       }
 
-  Atmosphere() = delete;
+  // use only for creating containers of Atmospheres!
+  Atmosphere() = default;
 
   // these are supported for initializing containers of Atmospheres
   Atmosphere(const Atmosphere &rhs) = default;

--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -21,10 +21,10 @@ public:
   /// Constructs an Atmosphere object holding the state for a single atmospheric
   /// column with the given planetary boundary layer height.
   /// All views must be set manually elsewhere or provided by a host model.
-  Atmosphere(const ColumnView T, const ColumnView p, const ColumnView qv,
-    const ColumnView qc, const ColumnView nqc, const ColumnView qi,
-    const ColumnView nqi, const ColumnView z, const ColumnView hdp,
-    const ColumnView cf, const ColumnView w, const Real pblh) :
+  Atmosphere(const ConstColumnView T, const ConstColumnView p, const ConstColumnView qv,
+    const ConstColumnView qc, const ConstColumnView nqc, const ConstColumnView qi,
+    const ConstColumnView nqi, const ConstColumnView z, const ConstColumnView hdp,
+    const ConstColumnView cf, const ConstColumnView w, const Real pblh) :
       num_levels_(T.extent(0)),
       temperature(T),
       pressure(p),

--- a/haero/haero.hpp
+++ b/haero/haero.hpp
@@ -58,6 +58,7 @@ using DiagnosticsView = typename DeviceType::view_3d<Real>;
 /// own their storage. This allows a host model to manage column data for
 /// any Haero aerosol packages.
 using ColumnView = ekat::Unmanaged<typename DeviceType::view_1d<Real>>;
+using ConstColumnView = ekat::Unmanaged<typename DeviceType::view_1d<const Real>>;
 
 // Returns haero's version string.
 const char *version();

--- a/haero/haero.hpp
+++ b/haero/haero.hpp
@@ -58,7 +58,8 @@ using DiagnosticsView = typename DeviceType::view_3d<Real>;
 /// own their storage. This allows a host model to manage column data for
 /// any Haero aerosol packages.
 using ColumnView = ekat::Unmanaged<typename DeviceType::view_1d<Real>>;
-using ConstColumnView = ekat::Unmanaged<typename DeviceType::view_1d<const Real>>;
+using ConstColumnView =
+    ekat::Unmanaged<typename DeviceType::view_1d<const Real>>;
 
 // Returns haero's version string.
 const char *version();

--- a/haero/testing.cpp
+++ b/haero/testing.cpp
@@ -87,9 +87,11 @@ Atmosphere create_atmosphere(int num_levels, Real pblh) {
   auto hydrostatic_dp = create_column_view(num_levels);
   auto cloud_fraction = create_column_view(num_levels);
   auto updraft_vel_ice_nucleation = create_column_view(num_levels);
-  return Atmosphere(temperature, pressure, vapor_mixing_ratio, liquid_mixing_ratio,
-    cloud_liquid_number_mixing_ratio, ice_mixing_ratio, cloud_ice_number_mixing_ratio,
-    height, hydrostatic_dp, cloud_fraction, updraft_vel_ice_nucleation, pblh);
+  return Atmosphere(temperature, pressure, vapor_mixing_ratio,
+                    liquid_mixing_ratio, cloud_liquid_number_mixing_ratio,
+                    ice_mixing_ratio, cloud_ice_number_mixing_ratio, height,
+                    hydrostatic_dp, cloud_fraction, updraft_vel_ice_nucleation,
+                    pblh);
 }
 
 ColumnView create_column_view(int num_levels) {

--- a/haero/testing.cpp
+++ b/haero/testing.cpp
@@ -76,19 +76,20 @@ std::map<size_t, std::unique_ptr<ColumnPool>> pools_{};
 namespace testing {
 
 Atmosphere create_atmosphere(int num_levels, Real pblh) {
-  Atmosphere atm(num_levels, pblh);
-  atm.temperature = create_column_view(num_levels);
-  atm.pressure = create_column_view(num_levels);
-  atm.vapor_mixing_ratio = create_column_view(num_levels);
-  atm.liquid_mixing_ratio = create_column_view(num_levels);
-  atm.cloud_liquid_number_mixing_ratio = create_column_view(num_levels);
-  atm.ice_mixing_ratio = create_column_view(num_levels);
-  atm.cloud_ice_number_mixing_ratio = create_column_view(num_levels);
-  atm.height = create_column_view(num_levels);
-  atm.hydrostatic_dp = create_column_view(num_levels);
-  atm.cloud_fraction = create_column_view(num_levels);
-  atm.updraft_vel_ice_nucleation = create_column_view(num_levels);
-  return atm;
+  auto temperature = create_column_view(num_levels);
+  auto pressure = create_column_view(num_levels);
+  auto vapor_mixing_ratio = create_column_view(num_levels);
+  auto liquid_mixing_ratio = create_column_view(num_levels);
+  auto cloud_liquid_number_mixing_ratio = create_column_view(num_levels);
+  auto ice_mixing_ratio = create_column_view(num_levels);
+  auto cloud_ice_number_mixing_ratio = create_column_view(num_levels);
+  auto height = create_column_view(num_levels);
+  auto hydrostatic_dp = create_column_view(num_levels);
+  auto cloud_fraction = create_column_view(num_levels);
+  auto updraft_vel_ice_nucleation = create_column_view(num_levels);
+  return Atmosphere(temperature, pressure, vapor_mixing_ratio, liquid_mixing_ratio,
+    cloud_liquid_number_mixing_ratio, ice_mixing_ratio, cloud_ice_number_mixing_ratio,
+    height, hydrostatic_dp, cloud_fraction, updraft_vel_ice_nucleation, pblh);
 }
 
 ColumnView create_column_view(int num_levels) {


### PR DESCRIPTION
@pbosler  added a new View type are required by EAMxx because of the way `const` fields are treated in our host model. This PR is a place for us to work through issues caused by the introduction of the `ConstColumnView` type, which is used to store all quantities in the `Atmosphere` class.