### PR TITLE
Adding an init method to AeroProcess

### DIFF
--- a/haero/aero_process.hpp
+++ b/haero/aero_process.hpp
@@ -79,6 +79,12 @@ public:
   //                            Public Interface
   //------------------------------------------------------------------------
 
+  /// On host: (re-)initializes the process with the given configuration
+  void init(const ProcessConfig& config) {
+    process_config_ = config;
+    process_impl_.init(aero_config_, process_config_);
+  }
+
   /// On host or device: Validates input aerosol and atmosphere data, returning
   /// true if all data is physically consistent (whatever that means), and false
   /// if not.

--- a/haero/aero_process.hpp
+++ b/haero/aero_process.hpp
@@ -80,7 +80,7 @@ public:
   //------------------------------------------------------------------------
 
   /// On host: (re-)initializes the process with the given configuration
-  void init(const ProcessConfig& config) {
+  void init(const ProcessConfig &config) {
     process_config_ = config;
     process_impl_.init(aero_config_, process_config_);
   }


### PR DESCRIPTION
It turns out it's useful to allow a aerosol process to be initialized after construction, so this PR just adds an `init` method that can be called whenever. We use this in EAMxx's MAMMicrophysics process.