### PR TITLE
haero bugfix--spacing in top-level CML.txt cmake_minimum_required()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 # Adjust CMake's module path.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")


### PR DESCRIPTION
Same deal as the mam4xx repo. Reusing the commit message...

So, to my surprise, when builds weren't working out properly for me, I realized that the machine I was using was running an old version of cmake, and that fact was not caught by the cmake_minimum_required (VERSION 3.17.0). As it turns out, the spacing (lack of) is rather important 🙃

Working properly now.