### PR TITLE
Atmosphere class takes num_levels as a constructor argument

### DIFF
--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -21,26 +21,30 @@ public:
   /// Constructs an Atmosphere object holding the state for a single atmospheric
   /// column with the given planetary boundary layer height.
   /// All views must be set manually elsewhere or provided by a host model.
-  Atmosphere(const ConstColumnView T, const ConstColumnView p,
+  Atmosphere(int num_levels, const ConstColumnView T, const ConstColumnView p,
              const ConstColumnView qv, const ConstColumnView qc,
              const ConstColumnView nqc, const ConstColumnView qi,
              const ConstColumnView nqi, const ConstColumnView z,
              const ConstColumnView hdp, const ConstColumnView cf,
              const ConstColumnView w, const Real pblh)
-      : num_levels_(T.extent(0)), temperature(T), pressure(p),
+      : num_levels_(num_levels), temperature(T), pressure(p),
         vapor_mixing_ratio(qv), liquid_mixing_ratio(qc),
         cloud_liquid_number_mixing_ratio(nqc), ice_mixing_ratio(qi),
         cloud_ice_number_mixing_ratio(nqi), height(z), hydrostatic_dp(hdp),
         cloud_fraction(cf), updraft_vel_ice_nucleation(w),
         planetary_boundary_layer_height(pblh) {
 
-    EKAT_ASSERT(T.extent(0) > 0);
-
-    EKAT_ASSERT(T.extent(0) == p.extent(0) && T.extent(0) == qv.extent(0) &&
-                T.extent(0) == qc.extent(0) && T.extent(0) == nqc.extent(0) &&
-                T.extent(0) == qi.extent(0) && T.extent(0) == nqi.extent(0) &&
-                T.extent(0) == z.extent(0) && T.extent(0) == hdp.extent(0) &&
-                T.extent(0) == cf.extent(0) && T.extent(0) == w.extent(0));
+    EKAT_ASSERT(T.extent(0) >= num_levels_);
+    EKAT_ASSERT(p.extent(0) >= num_levels_);
+    EKAT_ASSERT(qv.extent(0) >= num_levels_);
+    EKAT_ASSERT(qc.extent(0) >= num_levels_);
+    EKAT_ASSERT(nqc.extent(0) >= num_levels_);
+    EKAT_ASSERT(qi.extent(0) >= num_levels_);
+    EKAT_ASSERT(nqi.extent(0) >= num_levels_);
+    EKAT_ASSERT(z.extent(0) >= num_levels_);
+    EKAT_ASSERT(hdp.extent(0) >= num_levels_);
+    EKAT_ASSERT(cf.extent(0) >= num_levels_);
+    EKAT_ASSERT(w.extent(0) >= num_levels_);
 
     EKAT_ASSERT(pblh >= 0.0);
   }

--- a/haero/testing.cpp
+++ b/haero/testing.cpp
@@ -87,7 +87,7 @@ Atmosphere create_atmosphere(int num_levels, Real pblh) {
   auto hydrostatic_dp = create_column_view(num_levels);
   auto cloud_fraction = create_column_view(num_levels);
   auto updraft_vel_ice_nucleation = create_column_view(num_levels);
-  return Atmosphere(temperature, pressure, vapor_mixing_ratio,
+  return Atmosphere(num_levels, temperature, pressure, vapor_mixing_ratio,
                     liquid_mixing_ratio, cloud_liquid_number_mixing_ratio,
                     ice_mixing_ratio, cloud_ice_number_mixing_ratio, height,
                     hydrostatic_dp, cloud_fraction, updraft_vel_ice_nucleation,


### PR DESCRIPTION
This PR adds the number of vertical levels to the Atmosphere constructor, since we can't necessarily discern this number from unmanaged column views that may or may not contain packs!

With this and the corresponding mam4xx PR, we're able to run mam4xx inside EAMxx!