### PR TITLE
Removed references to Fortran from the README and Dockerfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,20 @@ To build Haero, you need:
 * [CMake v3.12+](https://cmake.org/)
 * GNU Make
 * reliable C and C++ compilers
-* a good Fortran compiler, such as GNU `gfortran` or Intel's `ifort` compiler
 * a working MPI installation (like [OpenMPI](https://www.open-mpi.org/) or
   [Mpich](https://www.mpich.org/)), if you're interested in multi-node
   parallelism.
 
-You can obtain all of these (except perhaps your favorite Fortran compiler)
-freely on the Linux and Mac platforms. On Linux, just use your favorite package
-manager. On a Mac, you can get the Clang C/C++ compiler by installing XCode, and
-then use a package manager like [Homebrew](https://brew.sh/) or
-[MacPorts](https://www.macports.org/) to get the rest.
+You can obtain all of these freely on the Linux and Mac platforms. On Linux,
+just use your favorite package manager. On a Mac, you can get the Clang C/C++
+compiler by installing XCode, and then use a package manager like
+[Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to get
+the rest.
 
 For example, to download the relevant software on your Mac using Homebrew, type
 
 ```
-brew install cmake gfortran openmpi
+brew install cmake openmpi
 ```
 
 ## Building the Model

--- a/tools/Dockerfile.ext
+++ b/tools/Dockerfile.ext
@@ -35,7 +35,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libopenmpi-dev \
   gcc \
   g++ \
-  gfortran \
   git \
   make \
   pkg-config \
@@ -50,7 +49,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     -DCMAKE_CXX_COMPILER=mpicxx \
     -DCMAKE_C_COMPILER=mpicc \
-    -DCMAKE_Fortran_COMPILER=mpif90 \
     -DHAERO_PRECISION=$PRECISION \
     -DHAERO_DEVICE=CPU \
     -DHAERO_DEVICE_ARCH=AMDAVX \


### PR DESCRIPTION
We haven't needed Fortran anywhere for a while now, so this PR just expels the Fortran-related instructions.