### PR TITLE
Updating to the latest version of EKAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,8 +140,10 @@ if (HAERO_ENABLE_MPI)
   message(STATUS "MPI is enabled")
 
   find_package(MPI REQUIRED COMPONENTS C)
-  include(EkatMpiUtils)
-  DisableMpiCxxBindings()
+  if (HAERO_BUILDS_EKAT)
+    include(EkatMpiUtils)
+    DisableMpiCxxBindings()
+  endif()
 
   include_directories(${MPI_C_INCLUDE_DIRS})
   set(HAERO_LIBRARIES ${MPI_C_LIBRARIES};${HAERO_LIBRARIES})

--- a/cmake/haero.cmake.in
+++ b/cmake/haero.cmake.in
@@ -44,4 +44,4 @@ set(HAERO_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include @CMAKE_INSTALL_PREFIX@/inc
 add_library(kokkos INTERFACE)
 target_link_libraries(kokkos INTERFACE kokkoscontainers kokkoscore)
 
-set(HAERO_LIBRARIES @HAERO_LIBRARIES@)
+set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;m)

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -16,7 +16,7 @@ endforeach()
 if (HAERO_BUILDS_EKAT)
   list(APPEND CMAKE_MODULE_PATH
        ${CMAKE_CURRENT_SOURCE_DIR}/ekat/cmake
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/cmake/pkg_build)
+       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/cmake/tpls)
   include(EkatBuildEkat)
   set(EKAT_ENABLE_MPI ${HAERO_ENABLE_MPI} CACHE BOOL "Enable MPI")
   set(EKAT_ENABLE_FORTRAN OFF CACHE BOOL "Enable EKAT Fortran support")


### PR DESCRIPTION
This PR fast-forwards our EKAT submodule (now several months old) to the latest version of EKAT. Only minor changes were necessary, which is a relief given the work that Luca put into improving EKAT's flexibility (including the ability to use E3SM's pre-built Kokkos library).