### PR TITLE
Added an option to enable/disable tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/ext/ekat/cmake/"
 #---------
 option(HAERO_ENABLE_GPU       "Enable GPU support"                         OFF)
 option(HAERO_ENABLE_MPI       "Enable MPI parallelism"                     ON)
+option(HAERO_ENABLE_TESTS     "Enable unit tests"                          ON)
 option(HAERO_SKIP_FIND_YAML_CPP "Enable SKIP FIND YAML_CPP"                OFF)
 # This option is only used in CI, where we have to use special sauce to get the
 # submodules working with SSH. No mortal user should be concerned with this.
@@ -200,8 +201,10 @@ include(GNUInstallDirs)
 link_directories("${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 
 # Testing
-include(CTest)
-enable_testing()
+if (HAERO_ENABLE_TESTS)
+  include(CTest)
+  enable_testing()
+endif()
 
 # Source directories.
 include_directories("${PROJECT_SOURCE_DIR}")

--- a/haero/CMakeLists.txt
+++ b/haero/CMakeLists.txt
@@ -47,7 +47,9 @@ set(HAERO_LIBRARIES haero;${HAERO_LIBRARIES})
 set(HAERO_LIBRARIES haero;${HAERO_LIBRARIES} PARENT_SCOPE)
 
 # unit tests
-add_subdirectory(tests)
+if (HAERO_ENABLE_TESTS)
+  add_subdirectory(tests)
+endif()
 
 # Installation targets
 install(TARGETS haero DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Something has changed in the EAMxx build system that causes linker failures when Haero tries to build its unit tests with `nvcc` and an MPI-capable compiler. This affects test executables built both by haero and mam4xx, so I'm making it possible to disable these things now, because this issue is not directly related to mam4 code.