### PR TITLE
add FPEs to mam4xx unit testing

### DIFF
--- a/haero/testing.cpp
+++ b/haero/testing.cpp
@@ -128,6 +128,9 @@ Surface create_surface() { return Surface(); }
 void ekat_initialize_test_session(int argc, char **argv,
                                   const bool print_config) {
   ekat::initialize_ekat_session(argc, argv, print_config);
+#ifdef EKAT_ENABLE_FPE
+  ekat::enable_fpes(haero::testing::default_fpes);
+#endif
 }
 
 // This implementation of ekat_finalize_test_session calls

--- a/haero/testing.hpp
+++ b/haero/testing.hpp
@@ -5,6 +5,8 @@
 #ifndef HAERO_TESTING_HPP
 #define HAERO_TESTING_HPP
 
+#include <cfenv>
+
 #include <haero/atmosphere.hpp>
 #include <haero/surface.hpp>
 
@@ -13,6 +15,8 @@ namespace haero {
 // The testing namespace contains tools that are useful only in testing
 // environments.
 namespace testing {
+
+constexpr int default_fpes = FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW;
 
 /// creates an Atmosphere object that stores a column of data with the given
 /// number of vertical levels and the given planetary boundary height


### PR DESCRIPTION
This modifies `testing.{c,h}pp` to enable FPEs, via EKAT, for mam4xx unit tests.