### PR TITLE
enable shared libs build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,6 @@ else()
 endif()
 message(STATUS "Using ${HAERO_PRECISION} precision floating point numbers")
 
-# We build static libraries only.
-set(BUILD_SHARED_LIBS OFF)
-
 # Figure out the system type.
 if (APPLE)
   set(SYS_FLAGS "-DAPPLE=1")


### PR DESCRIPTION
xref https://github.com/eagles-project/mam4xx/pull/323

> We would like to be able to build the entire eamxx project with shared libs enabled, so making the change here.

> There may be other changes needed elsewhere, but for now, I believe this is all that is needed.

> Putting this PR together so that you can see how this affects your CI and so on.

> Tagging @jeff-cohere @singhbalwinder @odiazib @bartgol