### PR TITLE
Updating ekat/kokkos version 4.5.01

### DIFF
--- a/cmake/haero.cmake.in
+++ b/cmake/haero.cmake.in
@@ -44,4 +44,7 @@ set(HAERO_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include @CMAKE_INSTALL_PREFIX@/inc
 add_library(kokkos INTERFACE)
 target_link_libraries(kokkos INTERFACE kokkoscontainers kokkoscore)
 
-set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;m)
+# CUDA stuff
+find_package(CUDAToolkit)
+
+set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;cuda;m)

--- a/cmake/haero.cmake.in
+++ b/cmake/haero.cmake.in
@@ -44,7 +44,13 @@ set(HAERO_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include @CMAKE_INSTALL_PREFIX@/inc
 add_library(kokkos INTERFACE)
 target_link_libraries(kokkos INTERFACE kokkoscontainers kokkoscore)
 
-# CUDA stuff
-find_package(CUDAToolkit)
+if (HAERO_ENABLE_GPU)
+  # FIXME: this assumes an NVIDIA GPU!
 
-set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;cuda;m)
+  # CUDA stuff
+  find_package(CUDAToolkit)
+
+  set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;cuda;m)
+else()
+  set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;m)
+endif()


### PR DESCRIPTION
We are currently using Kokkos version 4.2 in HEARO. After this update, it will use Kokkos version 4.5.01, the same as E3SM.