### PR TITLE
Removes `find(cuda_toolkit)` and warning fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,10 @@ endif()
 # Blessed version of clang-format.
 set(CLANG_FORMAT_VERSION 14)
 
+project (haero)
+
 enable_language(C)   # needed so ekat can detect MPI
 enable_language(CXX)
-
-project (haero)
 
 # Set all installation folders for third-party libraries, and figure out which
 # ones have to be built for Haero.

--- a/cmake/haero.cmake.in
+++ b/cmake/haero.cmake.in
@@ -46,7 +46,6 @@ target_link_libraries(kokkos INTERFACE kokkoscontainers kokkoscore)
 
 if (HAERO_ENABLE_GPU)
   # FIXME: this assumes an NVIDIA GPU!
-
   set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;cuda;m)
 else()
   set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;m)

--- a/cmake/haero.cmake.in
+++ b/cmake/haero.cmake.in
@@ -47,9 +47,6 @@ target_link_libraries(kokkos INTERFACE kokkoscontainers kokkoscore)
 if (HAERO_ENABLE_GPU)
   # FIXME: this assumes an NVIDIA GPU!
 
-  # CUDA stuff
-  find_package(CUDAToolkit)
-
   set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;cuda;m)
 else()
   set(HAERO_LIBRARIES @HAERO_LIBRARIES@;kokkos;m)


### PR DESCRIPTION
This removes the `find(cuda_toolkit)` call from `cmake/haero.cmake.in` that was failing and crashing builds in the AT2 container.

@odiazib Was this explicitly required for your pm-gpu builds? Would you mind running a quick test from this branch? I haven't run on PM for a while so I haven't gotten my environment solved yet

Similarly to the PR in Skywalker, this also adds a tiny fix for a cmake dev warning about `project()` and `enable_language()`