### PR TITLE
Update ekat submodule

### DIFF
--- a/cmake/HaeroConfigurePlatform.cmake
+++ b/cmake/HaeroConfigurePlatform.cmake
@@ -44,7 +44,7 @@ macro(HaeroConfigurePlatform)
   # target to determine whether it's part of a larger project
   set(HAERO_STANDALONE ON)
 
-  if (TARGET ekat) # we're part of a larger project
+  if (TARGET ekat::AllLibs) # we're part of a larger project
     message(STATUS "Building Haero within another project.")
     set(HAERO_STANDALONE OFF)
   else() # we're in standalone mode

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -14,22 +14,10 @@ endforeach()
 # E3SM Kokkos Application Toolkit (EKAT) library and friends.
 #----------------------------------------------------------------------------
 if (HAERO_BUILDS_EKAT)
-  list(APPEND CMAKE_MODULE_PATH
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/cmake
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/cmake/tpls)
-  include(EkatBuildEkat)
-  set(EKAT_ENABLE_MPI ${HAERO_ENABLE_MPI} CACHE BOOL "Enable MPI")
-  set(EKAT_ENABLE_FORTRAN OFF CACHE BOOL "Enable EKAT Fortran support")
-  set(EKAT_ENABLE_TESTS OFF CACHE BOOL "Enable EKAT tests")
-  set(Kokkos_ENABLE_LIBDL OFF CACHE BOOL "Enable broken Kokkos libdl support")
-  set(Kokkos_ENABLE_DEPRECATED_CODE_3 OFF CACHE BOOL "Enable deprecated code to avoid warnings of using deprecated functions.")
-  if (HAERO_SKIP_FIND_YAML_CPP)
-    set(EKAT_SKIP_FIND_YAML_CPP ON CACHE BOOL "EKAT will build yaml-cpp ")
-    message(STATUS "SKIP FIND YAML CPP")
-  else()
-    set(EKAT_SKIP_FIND_YAML_CPP OFF CACHE BOOL "EKAT will build yaml-cpp ")
-    message(STATUS "EKAT WILL LOOK FOR YAML-CPP")
-  endif()
+
+  # Set Kokkos config options
+  set(Kokkos_ENABLE_LIBDL OFF CACHE BOOL "Whether to enable the LIBDL library")
+  set(Kokkos_ENABLE_DEPRECATED_CODE_4 OFF CACHE BOOL "Whether code deprecated in major release 4 is available")
 
   if (CMAKE_BUILD_TYPE STREQUAL Release)
     set(Kokkos_ENABLE_DEBUG FALSE)
@@ -37,10 +25,6 @@ if (HAERO_BUILDS_EKAT)
   else()
     set(Kokkos_ENABLE_DEBUG TRUE)
     set(Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION OFF)
-  endif()
-  if (APPLE)
-    # floating point exceptions don't work properly on Macs
-    set(EKAT_ENABLE_FPE OFF CACHE BOOL "")
   endif()
   if (HAERO_ENABLE_GPU)
     if (HAERO_AMD_GPU)
@@ -69,43 +53,20 @@ if (HAERO_BUILDS_EKAT)
       set(Kokkos_ENABLE_PTHREAD ON CACHE BOOL "Enable pthreads Kokkos backend")
     endif()
   endif()
-  BuildEkat(PREFIX "HAERO")
-  list(APPEND EKAT_INCLUDE_DIRS
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/src
-       ${PROJECT_BINARY_DIR}/externals/ekat/src
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/extern/kokkos/tpls/desul/include
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/extern/kokkos/core/src
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/extern/kokkos/containers/src
-       ${PROJECT_BINARY_DIR}/externals/kokkos
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/extern/spdlog/include
-       ${CMAKE_CURRENT_SOURCE_DIR}/ekat/extern/yaml-cpp/include)
-  if (NOT TARGET yaml-cpp)
-    add_library(yaml-cpp STATIC IMPORTED GLOBAL)
-    if (CMAKE_BUILD_TYPE MATCHES "Debug")
-      set_target_properties(yaml-cpp PROPERTIES
-        IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libyaml-cppd.a)
-    else()
-      set_target_properties(yaml-cpp PROPERTIES
-        IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libyaml-cpp.a)
-    endif()
-  endif()
-  if (NOT TARGET spdlog)
-    add_library(spdlog STATIC IMPORTED GLOBAL)
-    if (CMAKE_BUILD_TYPE MATCHES "Debug")
-      set_target_properties(spdlog PROPERTIES
-        IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libspdlogd.a)
-    else()
-      set_target_properties(spdlog PROPERTIES
-        IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libspdlog.a)
-    endif()
-  endif()
+
+  # Set EKAT config options
+  set(EKAT_ENABLE_MPI ${HAERO_ENABLE_MPI} CACHE BOOL "Enable MPI")
+  set(EKAT_ENABLE_TESTS OFF CACHE BOOL "Whether tests should be built")
+  option(EKAT_ENABLE_KOKKOS       "Enable EKAT kokkos utilities" ON)
+  option(EKAT_ENABLE_YAML_PARSER  "Enable EKAT yaml parsing utilities" ON)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ekat ${CMAKE_BINARY_DIR}/externals/ekat)
 endif()
 
 add_library(ext_libraries INTERFACE)
-target_link_libraries (ext_libraries INTERFACE ekat;${HAERO_EXT_LIBRARIES})
+target_link_libraries (ext_libraries INTERFACE ekat::AllLibs;${HAERO_EXT_LIBRARIES})
 
 # Add all the libraries to the list maintained for the standalone build config file.
-set(HAERO_LIBRARIES ekat;${HAERO_EXT_LIBRARIES};${HAERO_LIBRARIES} PARENT_SCOPE)
+set(HAERO_LIBRARIES ekat::AllLibs;${HAERO_EXT_LIBRARIES};${HAERO_LIBRARIES} PARENT_SCOPE)
 list(REMOVE_DUPLICATES HAERO_EXT_INCLUDE_DIRS)
 set(HAERO_EXT_INCLUDE_DIRS ${HAERO_EXT_INCLUDE_DIRS} PARENT_SCOPE)
 

--- a/haero/atmosphere.hpp
+++ b/haero/atmosphere.hpp
@@ -7,7 +7,7 @@
 
 #include <haero/haero.hpp>
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_kernel_assert.hpp>
 
 namespace haero {
 

--- a/haero/floating_point.hpp
+++ b/haero/floating_point.hpp
@@ -8,7 +8,7 @@
 #include <haero/haero.hpp>
 
 #include <Kokkos_Core.hpp>
-#include <ekat/ekat_assert.hpp>
+#include <ekat_kernel_assert.hpp>
 
 namespace haero {
 

--- a/haero/haero_config.hpp.in
+++ b/haero/haero_config.hpp.in
@@ -4,7 +4,7 @@
 #ifndef HAERO_CONFIG_HPP
 #define HAERO_CONFIG_HPP
 
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
+#include <ekat_kokkos_types.hpp>
 
 namespace haero {
 

--- a/haero/math.hpp
+++ b/haero/math.hpp
@@ -7,8 +7,8 @@
 
 #include <haero/haero.hpp>
 
-#include <ekat/ekat_assert.hpp>
-#include <ekat/ekat_scalar_traits.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_scalar_traits.hpp>
 
 #include <Kokkos_NumericTraits.hpp>
 

--- a/haero/surface.hpp
+++ b/haero/surface.hpp
@@ -7,7 +7,7 @@
 
 #include <haero/haero.hpp>
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 namespace haero {
 

--- a/haero/testing.cpp
+++ b/haero/testing.cpp
@@ -4,7 +4,8 @@
 
 #include "testing.hpp"
 
-#include <ekat/ekat_session.hpp>
+#include <ekat_kokkos_session.hpp>
+#include <ekat_fpe.hpp>
 
 namespace haero {
 
@@ -127,15 +128,13 @@ Surface create_surface() { return Surface(); }
 // default provided by EKAT.
 void ekat_initialize_test_session(int argc, char **argv,
                                   const bool print_config) {
-  ekat::initialize_ekat_session(argc, argv, print_config);
-#ifdef EKAT_ENABLE_FPE
+  ekat::initialize_kokkos_session(argc, argv, print_config);
   ekat::enable_fpes(haero::testing::default_fpes);
-#endif
 }
 
 // This implementation of ekat_finalize_test_session calls
 // haero::testing::finalize() to deallocate all ColumnView pools.
 void ekat_finalize_test_session() {
   haero::testing::finalize();
-  ekat::finalize_ekat_session();
+  ekat::finalize_kokkos_session();
 }

--- a/haero/tests/CMakeLists.txt
+++ b/haero/tests/CMakeLists.txt
@@ -7,10 +7,10 @@ include(EkatCreateUnitTest)
 # We use the EkatCreateUnitTest CMake function to create unit tests that are
 # configured properly to work in the Kokkos environment provided by EKAT.
 # EkatCreateUnitTest must be called with the following options:
-# 1. LIBS ${HAERO_LIBRARIES} <-- links against Haero
-# 2. EXCLUDE_TEST_SESSION    <-- uses Haero's setup/breakdown functions
+# 1. LIBS ${HAERO_LIBRARIES}    <-- links against Haero
+# 2. USER_DEFINED_TEST_SESSION  <-- uses Haero's setup/breakdown functions
 
 EkatCreateUnitTest(math_tests math_tests.cpp
-                   LIBS ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
+  LIBS ${HAERO_LIBRARIES} USER_DEFINED_TEST_SESSION)
 EkatCreateUnitTest(testing_tests testing_tests.cpp
-                   LIBS ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
+  LIBS ${HAERO_LIBRARIES} USER_DEFINED_TEST_SESSION)

--- a/haero/utils.cpp
+++ b/haero/utils.cpp
@@ -4,7 +4,7 @@
 
 #include "utils.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 #include <cstring>
 #include <sstream>


### PR DESCRIPTION
Updates HAERO to use the new package-based version of ekat.

@jeff-cohere I am not 100% sure if what I did wrt to yaml/spdlog is correct; the cmake logic on that regard seemed "long". In particular,

- I no longer enable spdlog: I did not see it used in HAERO, but maybe you want it enabled b/c you want to _install_ haero+ekat for later use?
- I always enable yaml-cpp: I removed handling of HAERO_SKIP_FIND_YAML_CPP.

In both cases, I figured you can just invoke haero's config passing EKAT_XYX=ON/OFF vars, and get the corresponding option in ekat triggered. Here, I only hard-coded ON/OF for what Haero _knows for sure_ it's going to need...